### PR TITLE
feat: add credential_offer_uri

### DIFF
--- a/oid4vc-manager/src/managers/credential_issuer.rs
+++ b/oid4vc-manager/src/managers/credential_issuer.rs
@@ -48,6 +48,7 @@ impl<S: Storage<CFC>, CFC: CredentialFormatCollection> CredentialIssuerManager<S
                     issuer: issuer_url.clone(),
                     authorization_endpoint: issuer_url.join("/authorize")?,
                     token_endpoint: issuer_url.join("/token")?,
+                    pre_authorized_grant_anonymous_access_supported: Some(true),
                     ..Default::default()
                 },
             },

--- a/oid4vc-manager/src/managers/credential_issuer.rs
+++ b/oid4vc-manager/src/managers/credential_issuer.rs
@@ -20,7 +20,7 @@ pub struct CredentialIssuerManager<S: Storage<CFC>, CFC: CredentialFormatCollect
     pub listener: Arc<TcpListener>,
 }
 
-impl<S: Storage<CFC> + Clone, CFC: CredentialFormatCollection> CredentialIssuerManager<S, CFC> {
+impl<S: Storage<CFC>, CFC: CredentialFormatCollection> CredentialIssuerManager<S, CFC> {
     pub fn new<const N: usize>(
         listener: Option<TcpListener>,
         storage: S,
@@ -61,15 +61,15 @@ impl<S: Storage<CFC> + Clone, CFC: CredentialFormatCollection> CredentialIssuerM
         Ok(self.credential_issuer.metadata.credential_issuer.clone())
     }
 
-    pub fn credential_offer_uri(&self) -> Result<String> {
-        let credentials: Vec<_> = self
+    pub fn credential_offer(&self) -> Result<CredentialOffer<CFC>> {
+        let credentials: Vec<CredentialsObject<CFC>> = self
             .credential_issuer
             .metadata
             .credentials_supported
             .iter()
             .map(|credential| CredentialsObject::ByValue(credential.credential_format.clone()))
             .collect();
-        Ok(CredentialOfferQuery::CredentialOffer(CredentialOffer {
+        Ok(CredentialOffer {
             credential_issuer: self.credential_issuer.metadata.credential_issuer.clone(),
             credentials,
             grants: Some(Grants {
@@ -77,6 +77,18 @@ impl<S: Storage<CFC> + Clone, CFC: CredentialFormatCollection> CredentialIssuerM
                 pre_authorized_code: self.storage.get_pre_authorized_code(),
             }),
         })
-        .to_string())
+    }
+
+    pub fn credential_offer_uri(&self) -> Result<Url> {
+        let issuer_url = self.credential_issuer.metadata.credential_issuer.clone();
+        Ok(format!("{issuer_url}credential_offer").parse()?)
+    }
+
+    pub fn credential_offer_query(&self, by_reference: bool) -> Result<String> {
+        if by_reference {
+            Ok(CredentialOfferQuery::<CFC>::CredentialOfferUri(self.credential_offer_uri()?).to_string())
+        } else {
+            Ok(CredentialOfferQuery::CredentialOffer(self.credential_offer()?).to_string())
+        }
     }
 }

--- a/oid4vc-manager/src/managers/credential_issuer.rs
+++ b/oid4vc-manager/src/managers/credential_issuer.rs
@@ -81,7 +81,7 @@ impl<S: Storage<CFC>, CFC: CredentialFormatCollection> CredentialIssuerManager<S
 
     pub fn credential_offer_uri(&self) -> Result<Url> {
         let issuer_url = self.credential_issuer.metadata.credential_issuer.clone();
-        Ok(format!("{issuer_url}credential_offer").parse()?)
+        Ok(issuer_url.join("/credential_offer")?)
     }
 
     pub fn credential_offer_query(&self, by_reference: bool) -> Result<String> {

--- a/oid4vc-manager/src/servers/credential_issuer.rs
+++ b/oid4vc-manager/src/servers/credential_issuer.rs
@@ -65,6 +65,7 @@ impl<S: Storage<CFC> + Clone, CFC: CredentialFormatCollection + Clone + Deserial
                         get(oauth_authorization_server),
                     )
                     .route("/.well-known/openid-credential-issuer", get(openid_credential_issuer))
+                    .route("/credential_offer", get(credential_offer))
                     .route("/authorize", get(authorize))
                     .route("/token", post(token))
                     .route("/credential", post(credential))
@@ -119,6 +120,15 @@ async fn openid_credential_issuer<S: Storage<CFC>, CFC: CredentialFormatCollecti
     (
         StatusCode::OK,
         Json(credential_issuer_manager.credential_issuer.metadata),
+    )
+}
+
+async fn credential_offer<S: Storage<CFC>, CFC: CredentialFormatCollection>(
+    State(credential_issuer_manager): State<CredentialIssuerManager<S, CFC>>,
+) -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(credential_issuer_manager.credential_offer().unwrap()),
     )
 }
 

--- a/oid4vc-manager/tests/oid4vci/pre_authorized_code.rs
+++ b/oid4vc-manager/tests/oid4vci/pre_authorized_code.rs
@@ -15,10 +15,12 @@ use oid4vci::{
 use std::sync::Arc;
 
 #[rstest::rstest]
-#[case(false)]
-#[case(true)]
+#[case(false, false)]
+#[case(false, true)]
+#[case(true, false)]
+#[case(true, true)]
 #[tokio::test]
-async fn test_pre_authorized_code_flow(#[case] batch: bool) {
+async fn test_pre_authorized_code_flow(#[case] batch: bool, #[case] by_reference: bool) {
     // Setup the credential issuer.
     let mut credential_issuer = Server::<_, CredentialFormats>::setup(
         CredentialIssuerManager::new(
@@ -35,27 +37,29 @@ async fn test_pre_authorized_code_flow(#[case] batch: bool) {
     .detached(true);
     credential_issuer.start_server().await.unwrap();
 
-    // Get the credential offer url.
-    let credential_offer_url = credential_issuer
-        .credential_issuer_manager
-        .credential_offer_uri()
-        .unwrap();
-
-    // Parse the credential offer url.
-    let credential_offer: CredentialOffer = match credential_offer_url.parse().unwrap() {
-        CredentialOfferQuery::CredentialOffer(credential_offer) => credential_offer,
-        _ => unreachable!(),
-    };
-
-    // The credential offer contains a credential issuer url.
-    let credential_issuer_url = credential_offer.credential_issuer;
-
     // Create a new subject.
     let subject = KeySubject::new();
     let subject_did = subject.identifier().unwrap();
 
     // Create a new wallet.
     let wallet = Wallet::new(Arc::new(subject));
+
+    // Get the credential offer url.
+    let credential_offer_query = credential_issuer
+        .credential_issuer_manager
+        .credential_offer_query(by_reference)
+        .unwrap();
+
+    // Parse the credential offer url.
+    let credential_offer: CredentialOffer = match credential_offer_query.parse().unwrap() {
+        CredentialOfferQuery::CredentialOffer(credential_offer) => credential_offer,
+        CredentialOfferQuery::CredentialOfferUri(credential_offer_uri) => {
+            wallet.get_credential_offer(credential_offer_uri).await.unwrap()
+        }
+    };
+
+    // The credential offer contains a credential issuer url.
+    let credential_issuer_url = credential_offer.credential_issuer;
 
     // Get the authorization server metadata.
     let authorization_server_metadata = wallet

--- a/oid4vc-manager/tests/oid4vci/pre_authorized_code.rs
+++ b/oid4vc-manager/tests/oid4vci/pre_authorized_code.rs
@@ -67,6 +67,11 @@ async fn test_pre_authorized_code_flow(#[case] batch: bool, #[case] by_reference
         .await
         .unwrap();
 
+    assert_eq!(
+        authorization_server_metadata.pre_authorized_grant_anonymous_access_supported,
+        Some(true)
+    );
+
     // Get the credential issuer metadata.
     let credential_issuer_metadata = wallet
         .get_credential_issuer_metadata(credential_issuer_url.clone())

--- a/oid4vc-manager/tests/siopv2_oid4vp/implicit.rs
+++ b/oid4vc-manager/tests/siopv2_oid4vp/implicit.rs
@@ -131,7 +131,7 @@ async fn test_implicit_flow() {
     // Create presentation submission using the presentation definition and the verifiable credential.
     let presentation_submission = create_presentation_submission(
         &PRESENTATION_DEFINITION,
-        &serde_json::to_value(&verifiable_credential).unwrap(),
+        vec![serde_json::to_value(&verifiable_credential).unwrap()],
     )
     .unwrap();
 

--- a/oid4vci/src/credential_issuer/authorization_server_metadata.rs
+++ b/oid4vci/src/credential_issuer/authorization_server_metadata.rs
@@ -34,5 +34,7 @@ pub struct AuthorizationServerMetadata {
     pub introspection_endpoint_auth_methods_supported: Option<Vec<String>>,
     pub introspection_endpoint_auth_signing_alg_values_supported: Option<Vec<String>>,
     pub code_challenge_methods_supported: Option<Vec<String>>,
+    #[serde(rename = "pre-authorized_grant_anonymous_access_supported")]
+    pub pre_authorized_grant_anonymous_access_supported: Option<bool>,
     // Additional authorization server metadata parameters MAY also be used.
 }

--- a/oid4vci/src/credential_offer.rs
+++ b/oid4vci/src/credential_offer.rs
@@ -62,7 +62,14 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> std::str::FromStr for C
 impl<CFC: CredentialFormatCollection> std::fmt::Display for CredentialOfferQuery<CFC> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CredentialOfferQuery::CredentialOfferUri(url) => write!(f, "{}", url),
+            CredentialOfferQuery::CredentialOfferUri(uri) => {
+                let mut url = Url::parse("openid-credential-offer://").map_err(|_| std::fmt::Error)?;
+                url.query_pairs_mut().append_pair(
+                    "credential_offer_uri",
+                    &to_query_value(uri).map_err(|_| std::fmt::Error)?,
+                );
+                write!(f, "{}", url)
+            }
             CredentialOfferQuery::CredentialOffer(offer) => {
                 let mut url = Url::parse("openid-credential-offer://").map_err(|_| std::fmt::Error)?;
                 url.query_pairs_mut()

--- a/oid4vci/src/wallet/mod.rs
+++ b/oid4vci/src/wallet/mod.rs
@@ -5,6 +5,7 @@ use crate::credential_format_profiles::{CredentialFormatCollection, CredentialFo
 use crate::credential_issuer::{
     authorization_server_metadata::AuthorizationServerMetadata, credential_issuer_metadata::CredentialIssuerMetadata,
 };
+use crate::credential_offer::CredentialOffer;
 use crate::credential_request::{BatchCredentialRequest, CredentialRequest};
 use crate::credential_response::BatchCredentialResponse;
 use crate::proof::{Proof, ProofType};
@@ -30,6 +31,16 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
             client: reqwest::Client::new(),
             phantom: std::marker::PhantomData,
         }
+    }
+
+    pub async fn get_credential_offer(&self, credential_offer_uri: Url) -> Result<CredentialOffer> {
+        self.client
+            .get(credential_offer_uri)
+            .send()
+            .await?
+            .json::<CredentialOffer>()
+            .await
+            .map_err(|_| anyhow::anyhow!("Failed to get credential offer"))
     }
 
     pub async fn get_authorization_server_metadata(


### PR DESCRIPTION
# Description of change
Adds support for the `credential_offer_uri` parameter in `CredentialOfferQuery`. This functionality means support for credential offer by reference. This makes sure that the credential offer as a QR Code can stay small since the actual Credential Offer can be fetched from a credential offer endpoint.

Also adds the `pre_authorized_grant_anonymous_access_supported` parameter to the Authorization Server Metadata as specified in https://openid.bitbucket.io/connect/openid-4-verifiable-credential-issuance-1_0.html#name-oauth-20-authorization-serv

Allows for creating a `presentation_submission` with multiple credentials.

## Links to any relevant issues
n/a

## How the change has been tested
Tested in `oid4vc-manager/tests/oid4vci/pre_authorized_code.rs`.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes