### PR TITLE
feat: add `Clone`, `Default`, `PartialEq` implementations to several types

### DIFF
--- a/dif-presentation-exchange/src/presentation_submission.rs
+++ b/dif-presentation-exchange/src/presentation_submission.rs
@@ -4,7 +4,7 @@ use serde_with::skip_serializing_none;
 
 /// As specified in https://identity.foundation/presentation-exchange/#presentation-definition.
 #[allow(dead_code)]
-#[derive(Deserialize, Debug, Serialize, PartialEq)]
+#[derive(Deserialize, Debug, Serialize, PartialEq, Clone)]
 pub struct PresentationSubmission {
     // TODO: Must be unique.
     pub id: String,
@@ -15,7 +15,7 @@ pub struct PresentationSubmission {
 
 #[allow(dead_code)]
 #[skip_serializing_none]
-#[derive(Deserialize, Debug, Serialize, PartialEq)]
+#[derive(Deserialize, Debug, Serialize, PartialEq, Clone)]
 pub struct InputDescriptorMappingObject {
     // Matches the `id` property of the Input Descriptor in the Presentation Definition that this Presentation
     // Submission is related to.
@@ -31,7 +31,7 @@ pub struct InputDescriptorMappingObject {
 
 #[allow(dead_code)]
 #[skip_serializing_none]
-#[derive(Deserialize, Debug, Serialize, PartialEq)]
+#[derive(Deserialize, Debug, Serialize, PartialEq, Clone)]
 pub struct PathNested {
     pub id: Option<String>,
     pub format: ClaimFormatDesignation,

--- a/oid4vc-core/src/authorization_response.rs
+++ b/oid4vc-core/src/authorization_response.rs
@@ -5,7 +5,7 @@ use serde_with::skip_serializing_none;
 /// The [`AuthorizationResponse`] is a set of claims that are sent by a provider to a client. On top of some generic
 /// claims, it also contains a set of claims specific to an [`Extension`].
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthorizationResponse<E: Extension> {
     #[serde(skip)]
     pub redirect_uri: String,

--- a/oid4vc-manager/tests/siopv2/implicit.rs
+++ b/oid4vc-manager/tests/siopv2/implicit.rs
@@ -183,7 +183,7 @@ async fn test_implicit_flow() {
         .await
         .unwrap();
     assert_eq!(
-        id_token.standard_claims().to_owned(),
+        id_token.standard_claims,
         StandardClaimsValues {
             name: Some("Jane Doe".to_string()),
             email: Some("jane.doe@example.com".to_string()),

--- a/oid4vci/src/credential_format_profiles/mod.rs
+++ b/oid4vci/src/credential_format_profiles/mod.rs
@@ -90,7 +90,7 @@ where
 
 pub trait CredentialFormatCollection: Serialize + Send + Sync + Clone + std::fmt::Debug {}
 
-#[derive(Debug, Serialize, Clone, Eq, PartialEq, Deserialize)]
+#[derive(Debug, Serialize, Clone, Eq, PartialEq, Deserialize, Default)]
 #[serde(tag = "format")]
 pub enum CredentialFormats<C = ()>
 where
@@ -104,6 +104,8 @@ where
     LdpVc(C::Container<LdpVc>),
     #[serde(rename = "mso_mdoc")]
     MsoMdoc(C::Container<MsoMdoc>),
+    #[default]
+    Unknown,
 }
 
 impl<C> CredentialFormatCollection for CredentialFormats<C> where C: FormatExtension {}
@@ -118,6 +120,7 @@ where
             CredentialFormats::JwtVcJsonLd(_) => CredentialFormats::JwtVcJsonLd(()),
             CredentialFormats::LdpVc(_) => CredentialFormats::LdpVc(()),
             CredentialFormats::MsoMdoc(_) => CredentialFormats::MsoMdoc(()),
+            CredentialFormats::Unknown => CredentialFormats::Unknown,
         }
     }
 }
@@ -129,6 +132,7 @@ impl CredentialFormats<WithCredential> {
             CredentialFormats::JwtVcJsonLd(credential) => Ok(&credential.credential),
             CredentialFormats::LdpVc(credential) => Ok(&credential.credential),
             CredentialFormats::MsoMdoc(credential) => Ok(&credential.credential),
+            CredentialFormats::Unknown => Err(anyhow::anyhow!("Unknown credential format")),
         }
     }
 }

--- a/oid4vci/src/credential_issuer/authorization_server_metadata.rs
+++ b/oid4vci/src/credential_issuer/authorization_server_metadata.rs
@@ -5,7 +5,7 @@ use serde_with::skip_serializing_none;
 
 // Authorization Server Metadata as described here: https://www.rfc-editor.org/rfc/rfc8414.html#section-2
 #[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize, Derivative)]
+#[derive(Debug, Clone, Serialize, Deserialize, Derivative, PartialEq)]
 #[derivative(Default)]
 pub struct AuthorizationServerMetadata {
     // TODO: Temporary solution

--- a/oid4vci/src/credential_issuer/credential_issuer_metadata.rs
+++ b/oid4vci/src/credential_issuer/credential_issuer_metadata.rs
@@ -1,5 +1,6 @@
 use super::credentials_supported::CredentialsSupportedObject;
 use crate::credential_format_profiles::{CredentialFormatCollection, CredentialFormats, WithParameters};
+use derivative::Derivative;
 use oid4vc_core::JsonObject;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -8,13 +9,18 @@ use serde_with::skip_serializing_none;
 /// Credential Issuer Metadata as described here:
 /// https://openid.bitbucket.io/connect/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata.
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Derivative)]
+#[derivative(Default)]
 pub struct CredentialIssuerMetadata<CFC = CredentialFormats<WithParameters>>
 where
     CFC: CredentialFormatCollection,
 {
+    // TODO: Temporary solution
+    #[derivative(Default(value = "Url::parse(\"https://example.com\").unwrap()"))]
     pub credential_issuer: Url,
     pub authorization_server: Option<Url>,
+    // TODO: Temporary solution
+    #[derivative(Default(value = "Url::parse(\"https://example.com\").unwrap()"))]
     pub credential_endpoint: Url,
     pub batch_credential_endpoint: Option<Url>,
     pub deferred_credential_endpoint: Option<Url>,

--- a/oid4vci/src/credential_offer.rs
+++ b/oid4vci/src/credential_offer.rs
@@ -2,7 +2,7 @@ use crate::credential_format_profiles::{CredentialFormatCollection, CredentialFo
 use anyhow::Result;
 use oid4vc_core::{to_query_value, JsonObject};
 use reqwest::Url;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::skip_serializing_none;
 
@@ -43,7 +43,7 @@ where
     CredentialOffer(CredentialOffer<CFC>),
 }
 
-impl<CFC: CredentialFormatCollection + DeserializeOwned> std::str::FromStr for CredentialOfferQuery<CFC> {
+impl std::str::FromStr for CredentialOfferQuery {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self> {
@@ -108,6 +108,7 @@ mod tests {
         w3c_verifiable_credentials::{jwt_vc_json, ldp_vc},
         CredentialFormats, Parameters,
     };
+    use serde::de::DeserializeOwned;
     use serde_json::json;
 
     fn json_example<T>(path: &str) -> T

--- a/oid4vp/src/oid4vp.rs
+++ b/oid4vp/src/oid4vp.rs
@@ -83,7 +83,7 @@ impl Extension for OID4VP {
         })
     }
 
-    fn decode_authorization_response(
+    async fn decode_authorization_response(
         decoder: Decoder,
         response: &AuthorizationResponse<Self>,
     ) -> anyhow::Result<<Self::ResponseHandle as ResponseHandle>::ResponseItem> {
@@ -92,22 +92,21 @@ impl Extension for OID4VP {
             Oid4vpParams::Params { vp_token, .. } => block_on(decoder.decode(vp_token.to_owned()))?,
         };
 
-        block_on(async move {
-            join_all(
-                vp_token
-                    .verifiable_presentation()
-                    .verifiable_credential
-                    .iter()
-                    .map(|vc| async { decoder.decode(vc.as_str().to_owned()).await }),
-            )
-            .await
-            .into_iter()
-            .collect()
-        })
+        join_all(
+            vp_token
+                .verifiable_presentation()
+                .verifiable_credential
+                .iter()
+                .map(|vc| decoder.decode(vc.as_str().to_owned()))
+                .collect::<Vec<_>>(),
+        )
+        .await
+        .into_iter()
+        .collect()
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthorizationResponseParameters {
     #[serde(flatten, with = "serde_oid4vp_response")]
     pub oid4vp_parameters: Oid4vpParams,

--- a/oid4vp/src/oid4vp.rs
+++ b/oid4vp/src/oid4vp.rs
@@ -26,7 +26,7 @@ impl RequestHandle for RequestHandler {
 }
 
 /// This is the [`ResponseHandle`] for the [`OID4VP`] extension.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct ResponseHandler {}
 impl ResponseHandle for ResponseHandler {
     type Input = AuthorizationResponseInput;

--- a/oid4vp/src/oid4vp_params.rs
+++ b/oid4vp/src/oid4vp_params.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Represents the parameters of an OpenID4VP response. It can hold a Verifiable Presentation Token and a Presentation
 /// Submission, or a JWT containing them.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(untagged)]
 pub enum Oid4vpParams {
     Jwt {

--- a/siopv2/src/authorization_request.rs
+++ b/siopv2/src/authorization_request.rs
@@ -9,8 +9,10 @@ use oid4vc_core::{
     SubjectSyntaxType,
 };
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 /// [`AuthorizationRequest`] claims specific to [`SIOPv2`].
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthorizationRequestParameters {
     pub response_type: MustBe!("id_token"),

--- a/siopv2/src/relying_party.rs
+++ b/siopv2/src/relying_party.rs
@@ -42,6 +42,6 @@ impl RelyingParty {
         authorization_response: &AuthorizationResponse<E>,
         decoder: Decoder,
     ) -> Result<<E::ResponseHandle as ResponseHandle>::ResponseItem> {
-        E::decode_authorization_response(decoder, authorization_response)
+        E::decode_authorization_response(decoder, authorization_response).await
     }
 }

--- a/siopv2/src/siopv2.rs
+++ b/siopv2/src/siopv2.rs
@@ -2,7 +2,6 @@ use crate::authorization_request::{AuthorizationRequestBuilder, AuthorizationReq
 use crate::claims::StandardClaimsValues;
 use crate::token::id_token::IdToken;
 use chrono::{Duration, Utc};
-use futures::executor::block_on;
 use jsonwebtoken::{Algorithm, Header};
 use oid4vc_core::openid4vc_extension::{OpenID4VC, RequestHandle, ResponseHandle};
 use oid4vc_core::{
@@ -20,7 +19,7 @@ impl RequestHandle for RequestHandler {
 }
 
 /// This is the [`ResponseHandle`] for the [`SIOPv2`] extension.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct ResponseHandler {}
 impl ResponseHandle for ResponseHandler {
     type Input = StandardClaimsValues;
@@ -77,16 +76,16 @@ impl Extension for SIOPv2 {
         })
     }
 
-    fn decode_authorization_response(
+    async fn decode_authorization_response(
         decoder: Decoder,
         authorization_response: &AuthorizationResponse<Self>,
     ) -> anyhow::Result<<Self::ResponseHandle as ResponseHandle>::ResponseItem> {
         let token = authorization_response.extension.id_token.clone();
-        block_on(decoder.decode(token))
+        decoder.decode(token).await
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthorizationResponseParameters {
     pub id_token: String,
 }

--- a/siopv2/src/token/id_token.rs
+++ b/siopv2/src/token/id_token.rs
@@ -1,6 +1,5 @@
 use super::id_token_builder::IdTokenBuilder;
 use crate::{parse_other, StandardClaimsValues};
-use getset::Getters;
 use oid4vc_core::{JsonObject, RFC7519Claims};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -11,19 +10,17 @@ use serde_with::skip_serializing_none;
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
 pub struct IdToken {
     #[serde(flatten)]
-    #[getset(get = "pub")]
-    pub(super) rfc7519_claims: RFC7519Claims,
+    pub rfc7519_claims: RFC7519Claims,
     #[serde(flatten)]
-    #[getset(get = "pub")]
-    pub(super) standard_claims: StandardClaimsValues,
-    pub(super) auth_time: Option<i64>,
-    pub(super) nonce: Option<String>,
-    pub(super) acr: Option<String>,
-    pub(super) amr: Option<Vec<String>>,
-    pub(super) azp: Option<String>,
-    pub(super) sub_jwk: Option<SubJwk>,
+    pub standard_claims: StandardClaimsValues,
+    pub auth_time: Option<i64>,
+    pub nonce: Option<String>,
+    pub acr: Option<String>,
+    pub amr: Option<Vec<String>>,
+    pub azp: Option<String>,
+    pub sub_jwk: Option<SubJwk>,
     #[serde(flatten, deserialize_with = "parse_other")]
-    pub(super) other: Option<JsonObject>,
+    pub other: Option<JsonObject>,
 }
 
 impl IdToken {
@@ -35,9 +32,9 @@ impl IdToken {
 // TODO: Make feature complete.
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
 pub struct SubJwk {
-    pub(super) kty: String,
-    pub(super) n: String,
-    pub(super) e: String,
+    pub kty: String,
+    pub n: String,
+    pub e: String,
 }
 
 #[cfg(test)]

--- a/siopv2/src/token/id_token.rs
+++ b/siopv2/src/token/id_token.rs
@@ -8,7 +8,7 @@ use serde_with::skip_serializing_none;
 /// An SIOPv2 [`IdToken`] as specified in the [SIOPv2 specification](https://openid.net/specs/openid-connect-self-issued-v2-1_0.html#name-self-issued-id-token)
 /// and [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html#IDToken).
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Getters, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
 pub struct IdToken {
     #[serde(flatten)]
     #[getset(get = "pub")]
@@ -33,7 +33,7 @@ impl IdToken {
 }
 
 // TODO: Make feature complete.
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
 pub struct SubJwk {
     pub(super) kty: String,
     pub(super) n: String,


### PR DESCRIPTION
# Description of change
In order for the `oid4vc` crates to be easily used in other projects, some basic trait implementations are needed for several types. 

## Links to any relevant issues
https://github.com/impierce/ssi-agent/issues/21

## How the change has been tested
No new tests needed, existing tests still pass.
The changes have been tested trough the use of the `oid4vc` crates inside the ssi-agent.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes