### PR TITLE
chore: bump `identity_core` and `identity_credential`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ repository = "https://github.com/impierce/openid4vc"
 [workspace.dependencies]
 chrono = "0.4"
 getset = "0.1"
-identity_core = { version = "1.0.0-rc.1" }
-identity_credential = { version = "=0.7.0-alpha.7", default-features = false, features = ["validator", "credential", "presentation"] }
+identity_core = "1.2.0"
+identity_credential = { version = "1.2.0", default-features = false, features = ["validator", "credential", "presentation"] }
 is_empty = "0.2"
 jsonwebtoken = "8.2"
 monostate = "0.1"

--- a/siopv2/Cargo.toml
+++ b/siopv2/Cargo.toml
@@ -19,7 +19,6 @@ derive_more = "0.99.16"
 did_url = "0.1.0"
 futures = "0.3"
 getset.workspace = true
-identity_credential.workspace = true
 is_empty = "0.2.0"
 jsonwebtoken = "8.2.0"
 monostate.workspace = true
@@ -32,7 +31,6 @@ serde_urlencoded = "0.7.1"
 serde_with.workspace = true
 tokio.workspace = true
 url = { version = "2.3.1", features = ["serde"] }
-
 
 [dev-dependencies]
 oid4vc-core = { path = "../oid4vc-core", features = ["test-utils"] }


### PR DESCRIPTION
# Description of change
See title

This bump is necessary in order to integrate properly with the ssi-agent repository as well as with UniMe.

## Links to any relevant issues
https://github.com/impierce/ssi-agent/issues/22

## How the change has been tested
Existing tests still pass. 
Manual testing in ssi-agent still works.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes