### PR TITLE
feat: allow for `DidMethod` with partitioned namespace

### DIFF
--- a/oid4vc-core/src/subject_syntax_type.rs
+++ b/oid4vc-core/src/subject_syntax_type.rs
@@ -77,7 +77,7 @@ pub struct DidMethod {
 
 impl DidMethod {
     pub fn from_str_with_namespace(s: &str) -> Result<Self, serde_json::Error> {
-        let mut did_scheme = s.splitn(3, ':');
+        let mut did_scheme = s.splitn(4, ':');
 
         match (
             did_scheme.next(),
@@ -113,13 +113,8 @@ impl FromStr for DidMethod {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut did_scheme = s.splitn(3, ':');
 
-        match (
-            did_scheme.next(),
-            did_scheme.next(),
-            did_scheme.next(),
-            did_scheme.next(),
-        ) {
-            (Some("did"), Some(method), _, None) if !method.is_empty() && method.chars().all(char::is_alphanumeric) => {
+        match (did_scheme.next(), did_scheme.next(), did_scheme.next()) {
+            (Some("did"), Some(method), None) if !method.is_empty() && method.chars().all(char::is_alphanumeric) => {
                 Ok(DidMethod {
                     method_name: method.to_owned(),
                     namespace: None,
@@ -152,6 +147,7 @@ mod tests {
         assert!(DidMethod::from_str("invalid:").is_err());
         assert!(DidMethod::from_str("did:example_").is_err());
         assert!(DidMethod::from_str("did:example").is_ok());
+        assert!(DidMethod::from_str("did:example:").is_err());
 
         assert_eq!(DidMethod::from_str("did:example").unwrap().to_string(), "did:example");
         assert_eq!(

--- a/oid4vc-core/src/subject_syntax_type.rs
+++ b/oid4vc-core/src/subject_syntax_type.rs
@@ -76,6 +76,10 @@ pub struct DidMethod {
 }
 
 impl DidMethod {
+    // TODO(selv): SIOPv2 has a (probably unintended) restriction on how to communicate support for DID Methods in a
+    // Providers Metadata where namespaces are not allowed. So strictly speaking namespaces should not be allowed. An
+    // issue has been opened to address this problem. For more information, see:
+    // https://github.com/openid/SIOPv2/issues/22
     pub fn from_str_with_namespace(s: &str) -> Result<Self, serde_json::Error> {
         let mut did_scheme = s.splitn(4, ':');
 

--- a/oid4vc-core/src/subject_syntax_type.rs
+++ b/oid4vc-core/src/subject_syntax_type.rs
@@ -16,7 +16,9 @@ impl FromStr for SubjectSyntaxType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "urn:ietf:params:oauth:jwk-thumbprint" => Ok(SubjectSyntaxType::JwkThumbprint),
-            _ => Ok(SubjectSyntaxType::Did(DidMethod::from_str(s)?)),
+            _ => Ok(SubjectSyntaxType::Did(
+                DidMethod::from_str_with_namespace(s).or_else(|_| DidMethod::from_str(s))?,
+            )),
         }
     }
 }

--- a/oid4vc-core/src/subject_syntax_type.rs
+++ b/oid4vc-core/src/subject_syntax_type.rs
@@ -1,5 +1,5 @@
 use serde::{de::Error, Deserialize, Deserializer, Serialize};
-use serde_with::{DeserializeFromStr, SerializeDisplay};
+use serde_with::SerializeDisplay;
 use std::{fmt::Display, str::FromStr};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -69,7 +69,7 @@ pub mod serde_unit_variant {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, DeserializeFromStr, SerializeDisplay)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeDisplay)]
 pub struct DidMethod {
     method_name: String,
     namespace: Option<String>,
@@ -99,6 +99,18 @@ impl DidMethod {
             }
             _ => Err(Error::custom("Invalid DID method")),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for DidMethod {
+    fn deserialize<D>(deserializer: D) -> Result<DidMethod, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        DidMethod::from_str_with_namespace(&s)
+            .or_else(|_| DidMethod::from_str(&s))
+            .map_err(D::Error::custom)
     }
 }
 


### PR DESCRIPTION
# Description of change
This change allows for `DidMethod`'s with namespace support. For more information see #72, but in short:
now not just `did:key`, `did:jwk` and `did:iota` can be parsed to a `DidMethod` struct, but `did:iota:smr` and `did:iota:rms` are valid `DidMethod`'s as well.

Disclaimer:
The SIOPv2 specification has a (probably unintended) too restrictive requirement regarding displaying supported DID Methods in a Providers metadata (that doesn't allow for namespaces). There is an open issue for this which will will hopefully result in this restriction to be removed: https://github.com/openid/SIOPv2/issues/22.

## Links to any relevant issues
- #72 
- https://github.com/openid/SIOPv2/issues/22

## How the change has been tested
Added unit test..

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes