### PR TITLE
feat: bootstrap SD-JWT support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,11 @@ repository = "https://github.com/impierce/openid4vc"
 [workspace.dependencies]
 chrono = "0.4"
 getset = "0.1"
-identity_core = "1.2.0"
-identity_credential = { version = "1.2.0", default-features = false, features = ["validator", "credential", "presentation"] }
+# TODO: Set identity.rs dependencies back to the official repository once the following PR is merged: https://github.com/iotaledger/identity.rs/pull/1413
+# identity_core = { git = "https://github.com/iotaledger/identity.rs", branch = "feat/sd-jwt-vc" }
+# identity_credential = { git = "https://github.com/iotaledger/identity.rs", branch = "feat/sd-jwt-vc", default-features = false, features = ["validator", "credential", "presentation"] }
+identity_core = { git = "https://github.com/impierce/identity.rs", rev = "309c399" }
+identity_credential = { git = "https://github.com/impierce/identity.rs", rev = "309c399", default-features = false, features = ["validator", "credential", "presentation", "sd-jwt-vc"] }
 is_empty = "0.2"
 jsonwebtoken = "9.3"
 monostate = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,8 @@ repository = "https://github.com/impierce/openid4vc"
 chrono = "0.4"
 getset = "0.1"
 # TODO: Set identity.rs dependencies back to the official repository once the following PR is merged: https://github.com/iotaledger/identity.rs/pull/1413
-# identity_core = { git = "https://github.com/iotaledger/identity.rs", branch = "feat/sd-jwt-vc" }
-# identity_credential = { git = "https://github.com/iotaledger/identity.rs", branch = "feat/sd-jwt-vc", default-features = false, features = ["validator", "credential", "presentation"] }
-identity_core = { git = "https://github.com/impierce/identity.rs", rev = "309c399" }
-identity_credential = { git = "https://github.com/impierce/identity.rs", rev = "309c399", default-features = false, features = ["validator", "credential", "presentation", "sd-jwt-vc"] }
+identity_core = { git = "https://github.com/iotaledger/identity.rs", branch = "feat/sd-jwt-vc" }
+identity_credential = { git = "https://github.com/iotaledger/identity.rs", branch = "feat/sd-jwt-vc", default-features = false, features = ["validator", "credential", "presentation", "sd-jwt-vc"] }
 is_empty = "0.2"
 jsonwebtoken = "9.3"
 monostate = "0.1"

--- a/dif-presentation-exchange/src/input_evaluation.rs
+++ b/dif-presentation-exchange/src/input_evaluation.rs
@@ -89,17 +89,7 @@ mod tests {
         presentation_definition::{Constraints, Field},
         InputDescriptor,
     };
-    use serde::de::DeserializeOwned;
-    use std::{fs::File, path::Path};
-
-    fn json_example<T>(path: &str) -> T
-    where
-        T: DeserializeOwned,
-    {
-        let file_path = Path::new(path);
-        let file = File::open(file_path).expect("file does not exist");
-        serde_json::from_reader::<_, T>(file).expect("could not parse json")
-    }
+    use serde_json::{from_str, Value};
 
     fn input_descriptor(constraints: Constraints) -> InputDescriptor {
         InputDescriptor {
@@ -114,7 +104,8 @@ mod tests {
 
     #[test]
     fn test_constraints() {
-        let credential = json_example::<serde_json::Value>("../oid4vp/tests/examples/credentials/jwt_vc.json");
+        let credential =
+            from_str::<Value>(include_str!("../../oid4vp/tests/examples/credentials/jwt_vc.json")).unwrap();
 
         // Has NO fields.
         assert!(!evaluate_input(&input_descriptor(Constraints::default()), &credential));
@@ -131,7 +122,7 @@ mod tests {
             &credential
         ));
 
-        // // Has ONE INVALID field.
+        // Has ONE INVALID field.
         assert!(!evaluate_input(
             &input_descriptor(Constraints {
                 fields: Some(vec![Field {
@@ -201,7 +192,8 @@ mod tests {
 
     #[test]
     fn test_field() {
-        let credential = json_example::<serde_json::Value>("../oid4vp/tests/examples/credentials/jwt_vc.json");
+        let credential =
+            from_str::<Value>(include_str!("../../oid4vp/tests/examples/credentials/jwt_vc.json")).unwrap();
 
         // Has NO path.
         assert!(!evaluate_input(

--- a/dif-presentation-exchange/src/presentation_definition.rs
+++ b/dif-presentation-exchange/src/presentation_definition.rs
@@ -54,6 +54,8 @@ pub enum ClaimFormatDesignation {
     AcVc,
     AcVp,
     MsoMdoc,
+    #[serde(rename = "vc+sd-jwt")]
+    VcSdJwt,
 }
 
 #[allow(dead_code)]
@@ -62,6 +64,13 @@ pub enum ClaimFormatDesignation {
 pub enum ClaimFormatProperty {
     Alg(Vec<Algorithm>),
     ProofType(Vec<String>),
+    #[serde(untagged)]
+    SdJwt {
+        #[serde(rename = "sd-jwt_alg_values", default, skip_serializing_if = "Vec::is_empty")]
+        sd_jwt_alg_values: Vec<Algorithm>,
+        #[serde(rename = "kb-jwt_alg_values", default, skip_serializing_if = "Vec::is_empty")]
+        kb_jwt_alg_values: Vec<Algorithm>,
+    },
 }
 
 #[allow(dead_code)]
@@ -385,6 +394,27 @@ mod tests {
                 purpose: None,
             },
             json_example::<PresentationDefinition>("../oid4vp/tests/examples/request/vp_token_type_only.json")
+        );
+    }
+
+    #[test]
+    fn test_claim_format_property() {
+        assert_eq!(
+            ClaimFormatProperty::Alg(vec![Algorithm::EdDSA, Algorithm::ES256]),
+            serde_json::from_str(r#"{"alg":["EdDSA","ES256"]}"#).unwrap()
+        );
+
+        assert_eq!(
+            ClaimFormatProperty::ProofType(vec!["JsonWebSignature2020".to_string()]),
+            serde_json::from_str(r#"{"proof_type":["JsonWebSignature2020"]}"#).unwrap()
+        );
+
+        assert_eq!(
+            ClaimFormatProperty::SdJwt {
+                sd_jwt_alg_values: vec![Algorithm::EdDSA],
+                kb_jwt_alg_values: vec![Algorithm::ES256],
+            },
+            serde_json::from_str(r#"{"sd-jwt_alg_values":["EdDSA"],"kb-jwt_alg_values":["ES256"]}"#).unwrap()
         );
     }
 }

--- a/dif-presentation-exchange/src/presentation_definition.rs
+++ b/dif-presentation-exchange/src/presentation_definition.rs
@@ -114,17 +114,7 @@ pub struct Field {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::de::DeserializeOwned;
-    use std::{fs::File, path::Path};
-
-    fn json_example<T>(path: &str) -> T
-    where
-        T: DeserializeOwned,
-    {
-        let file_path = Path::new(path);
-        let file = File::open(file_path).expect("file does not exist");
-        serde_json::from_reader::<_, T>(file).expect("could not parse json")
-    }
+    use serde_json::from_str;
 
     #[test]
     fn test_deserialize_presentation_definition() {
@@ -166,7 +156,8 @@ mod tests {
                 }],
                 purpose: None,
             },
-            json_example::<PresentationDefinition>("../oid4vp/tests/examples/request/pd_ac_vc_sd.json")
+            from_str::<PresentationDefinition>(include_str!("../../oid4vp/tests/examples/request/pd_ac_vc_sd.json"))
+                .unwrap()
         );
 
         assert_eq!(
@@ -197,7 +188,8 @@ mod tests {
                 }],
                 purpose: None,
             },
-            json_example::<PresentationDefinition>("../oid4vp/tests/examples/request/pd_ac_vc.json")
+            from_str::<PresentationDefinition>(include_str!("../../oid4vp/tests/examples/request/pd_ac_vc.json"))
+                .unwrap()
         );
 
         assert_eq!(
@@ -230,7 +222,8 @@ mod tests {
                 }],
                 purpose: None,
             },
-            json_example::<PresentationDefinition>("../oid4vp/tests/examples/request/pd_jwt_vc.json")
+            from_str::<PresentationDefinition>(include_str!("../../oid4vp/tests/examples/request/pd_jwt_vc.json"))
+                .unwrap()
         );
 
         assert_eq!(
@@ -263,7 +256,8 @@ mod tests {
                 }],
                 purpose: None,
             },
-            json_example::<PresentationDefinition>("../oid4vp/tests/examples/request/pd_ldp_vc.json")
+            from_str::<PresentationDefinition>(include_str!("../../oid4vp/tests/examples/request/pd_ldp_vc.json"))
+                .unwrap()
         );
 
         // TODO: report json file bug + add retention feature: https://identity.foundation/presentation-exchange/spec/v2.0.0/#retention-feature
@@ -317,7 +311,10 @@ mod tests {
                 }],
                 purpose: None,
             },
-            json_example::<PresentationDefinition>("../oid4vp/tests/examples/request/pd_mdl_iso_cbor.json")
+            from_str::<PresentationDefinition>(include_str!(
+                "../../oid4vp/tests/examples/request/pd_mdl_iso_cbor.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -362,7 +359,10 @@ mod tests {
                 }],
                 purpose: None,
             },
-            json_example::<PresentationDefinition>("../oid4vp/tests/examples/request/vp_token_type_and_claims.json")
+            from_str::<PresentationDefinition>(include_str!(
+                "../../oid4vp/tests/examples/request/vp_token_type_and_claims.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -393,7 +393,10 @@ mod tests {
                 }],
                 purpose: None,
             },
-            json_example::<PresentationDefinition>("../oid4vp/tests/examples/request/vp_token_type_only.json")
+            from_str::<PresentationDefinition>(include_str!(
+                "../../oid4vp/tests/examples/request/vp_token_type_only.json"
+            ))
+            .unwrap()
         );
     }
 

--- a/dif-presentation-exchange/src/presentation_submission.rs
+++ b/dif-presentation-exchange/src/presentation_submission.rs
@@ -41,18 +41,9 @@ pub struct PathNested {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use serde::de::DeserializeOwned;
-    use std::{fs::File, path::Path};
+    use serde_json::from_str;
 
-    fn json_example<T>(path: &str) -> T
-    where
-        T: DeserializeOwned,
-    {
-        let file_path = Path::new(path);
-        let file = File::open(file_path).expect("file does not exist");
-        serde_json::from_reader::<_, T>(file).expect("could not parse json")
-    }
+    use super::*;
 
     #[test]
     fn test_deserialize_presentation_submission() {
@@ -85,9 +76,10 @@ mod tests {
                     }
                 ]
             },
-            json_example::<PresentationSubmission>(
-                "../oid4vp/tests/examples/response/presentation_submission_multiple_vps.json"
-            )
+            from_str::<PresentationSubmission>(include_str!(
+                "../../oid4vp/tests/examples/response/presentation_submission_multiple_vps.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -106,7 +98,10 @@ mod tests {
                     })
                 }]
             },
-            json_example::<PresentationSubmission>("../oid4vp/tests/examples/response/presentation_submission.json")
+            from_str::<PresentationSubmission>(include_str!(
+                "../../oid4vp/tests/examples/response/presentation_submission.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -125,7 +120,8 @@ mod tests {
                     })
                 }]
             },
-            json_example::<PresentationSubmission>("../oid4vp/tests/examples/response/ps_ac_vc_sd.json")
+            from_str::<PresentationSubmission>(include_str!("../../oid4vp/tests/examples/response/ps_ac_vc_sd.json"))
+                .unwrap()
         );
 
         assert_eq!(
@@ -144,7 +140,8 @@ mod tests {
                     })
                 }]
             },
-            json_example::<PresentationSubmission>("../oid4vp/tests/examples/response/ps_jwt_vc.json")
+            from_str::<PresentationSubmission>(include_str!("../../oid4vp/tests/examples/response/ps_jwt_vc.json"))
+                .unwrap()
         );
 
         assert_eq!(
@@ -163,7 +160,8 @@ mod tests {
                     })
                 }]
             },
-            json_example::<PresentationSubmission>("../oid4vp/tests/examples/response/ps_ldp_vc.json")
+            from_str::<PresentationSubmission>(include_str!("../../oid4vp/tests/examples/response/ps_ldp_vc.json"))
+                .unwrap()
         );
 
         assert_eq!(
@@ -177,7 +175,10 @@ mod tests {
                     path_nested: None
                 }]
             },
-            json_example::<PresentationSubmission>("../oid4vp/tests/examples/response/ps_mdl_iso_cbor.json")
+            from_str::<PresentationSubmission>(include_str!(
+                "../../oid4vp/tests/examples/response/ps_mdl_iso_cbor.json"
+            ))
+            .unwrap()
         );
     }
 }

--- a/oid4vc-manager/src/managers/presentation.rs
+++ b/oid4vc-manager/src/managers/presentation.rs
@@ -52,8 +52,7 @@ pub fn create_sd_jwt_presentation_submission(
     let descriptor_map = presentation_definition
         .input_descriptors()
         .iter()
-        .enumerate()
-        .filter_map(|(_index, input_descriptor)| {
+        .filter_map(|input_descriptor| {
             credentials.iter().find_map(|credential| {
                 evaluate_input(input_descriptor, credential).then_some(InputDescriptorMappingObject {
                     id: input_descriptor.id().clone(),

--- a/oid4vc-manager/src/managers/presentation.rs
+++ b/oid4vc-manager/src/managers/presentation.rs
@@ -6,7 +6,7 @@ use oid4vp::{
 
 /// Takes a [`PresentationDefinition`] and a credential and creates a [`PresentationSubmission`] from it if the
 /// credential meets the requirements.
-// TODO: make VP/VC fromat agnostic. In current form only jwt_vp_json + jwt_vc_json are supported.
+// TODO: make VP/VC format agnostic. In current form only jwt_vp_json + jwt_vc_json are supported.
 pub fn create_presentation_submission(
     presentation_definition: &PresentationDefinition,
     credentials: &[serde_json::Value],
@@ -17,23 +17,51 @@ pub fn create_presentation_submission(
         .input_descriptors()
         .iter()
         .enumerate()
-        .map(|(index, input_descriptor)| {
-            credentials
-                .iter()
-                .find_map(|credential| {
-                    evaluate_input(input_descriptor, credential).then_some(InputDescriptorMappingObject {
-                        id: input_descriptor.id().clone(),
-                        format: ClaimFormatDesignation::JwtVpJson,
-                        path: "$".to_string(),
-                        path_nested: Some(PathNested {
-                            id: None,
-                            path: format!("$.vp.verifiableCredential[{}]", index),
-                            format: ClaimFormatDesignation::JwtVcJson,
-                            path_nested: None,
-                        }),
-                    })
+        .filter_map(|(index, input_descriptor)| {
+            credentials.iter().find_map(|credential| {
+                evaluate_input(input_descriptor, credential).then_some(InputDescriptorMappingObject {
+                    id: input_descriptor.id().clone(),
+                    format: ClaimFormatDesignation::JwtVpJson,
+                    path: "$".to_string(),
+                    path_nested: Some(PathNested {
+                        id: None,
+                        path: format!("$.vp.verifiableCredential[{}]", index),
+                        format: ClaimFormatDesignation::JwtVcJson,
+                        path_nested: None,
+                    }),
                 })
-                .unwrap()
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(PresentationSubmission {
+        id,
+        definition_id,
+        descriptor_map,
+    })
+}
+
+// Creates a `PresentationSubmission` for a vc-sd-jwt presentation.
+// TODO:remove this function and make sure that `create_presentation_submission` can generate submissions regardless of
+// the VP/VC format.
+pub fn create_sd_jwt_presentation_submission(
+    presentation_definition: &PresentationDefinition,
+    credentials: &[serde_json::Value],
+) -> Result<PresentationSubmission> {
+    let id = "Submission ID".to_string();
+    let definition_id = presentation_definition.id().clone();
+    let descriptor_map = presentation_definition
+        .input_descriptors()
+        .iter()
+        .enumerate()
+        .filter_map(|(_index, input_descriptor)| {
+            credentials.iter().find_map(|credential| {
+                evaluate_input(input_descriptor, credential).then_some(InputDescriptorMappingObject {
+                    id: input_descriptor.id().clone(),
+                    format: ClaimFormatDesignation::VcSdJwt,
+                    path: "$".to_string(),
+                    path_nested: None,
+                })
+            })
         })
         .collect::<Vec<_>>();
     Ok(PresentationSubmission {

--- a/oid4vc-manager/src/managers/presentation.rs
+++ b/oid4vc-manager/src/managers/presentation.rs
@@ -6,7 +6,8 @@ use oid4vp::{
 
 /// Takes a [`PresentationDefinition`] and a credential and creates a [`PresentationSubmission`] from it if the
 /// credential meets the requirements.
-// TODO: make VP/VC format agnostic. In current form only jwt_vp_json + jwt_vc_json are supported.
+// TODO: make VP/VC format agnostic. In current form only jwt_vp_json + jwt_vc_json are supported. Also, make sure that
+// an error is returned if the credentials do not meet the requirements in the `PresentationDefinition`.
 pub fn create_presentation_submission(
     id: String,
     presentation_definition: &PresentationDefinition,

--- a/oid4vc-manager/src/managers/presentation.rs
+++ b/oid4vc-manager/src/managers/presentation.rs
@@ -8,10 +8,10 @@ use oid4vp::{
 /// credential meets the requirements.
 // TODO: make VP/VC format agnostic. In current form only jwt_vp_json + jwt_vc_json are supported.
 pub fn create_presentation_submission(
+    id: String,
     presentation_definition: &PresentationDefinition,
     credentials: &[serde_json::Value],
 ) -> Result<PresentationSubmission> {
-    let id = "Submission ID".to_string();
     let definition_id = presentation_definition.id().clone();
     let descriptor_map = presentation_definition
         .input_descriptors()
@@ -40,14 +40,14 @@ pub fn create_presentation_submission(
     })
 }
 
-// Creates a `PresentationSubmission` for a vc-sd-jwt presentation.
+// Creates a `PresentationSubmission` for a vc+sd-jwt presentation.
 // TODO:remove this function and make sure that `create_presentation_submission` can generate submissions regardless of
 // the VP/VC format.
 pub fn create_sd_jwt_presentation_submission(
+    id: String,
     presentation_definition: &PresentationDefinition,
     credentials: &[serde_json::Value],
 ) -> Result<PresentationSubmission> {
-    let id = "Submission ID".to_string();
     let definition_id = presentation_definition.id().clone();
     let descriptor_map = presentation_definition
         .input_descriptors()
@@ -68,4 +68,201 @@ pub fn create_sd_jwt_presentation_submission(
         definition_id,
         descriptor_map,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_create_presentation_submission() {
+        // With example data from:
+        // https://openid.net/specs/openid-4-verifiable-presentations-1_0-21.html#name-vc-signed-as-a-jwt-not-usin
+
+        let presentation_definition: PresentationDefinition = serde_json::from_value(json!(
+            {
+                "id": "example_jwt_vc",
+                "input_descriptors": [
+                    {
+                        "id": "id_credential",
+                        "format": {
+                            "jwt_vc_json": {
+                                "proof_type": [
+                                    "JsonWebSignature2020"
+                                ]
+                            }
+                        },
+                        "constraints": {
+                            "fields": [
+                                {
+                                    "path": [
+                                        "$.vc.type"
+                                    ],
+                                    "filter": {
+                                        "type": "array",
+                                        "contains": {
+                                            "const": "IDCredential"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ))
+        .unwrap();
+
+        let credential_data = json!(
+            {
+                "iss": "https://example.gov/issuers/565049",
+                "nbf": 1262304000,
+                "jti": "http://example.gov/credentials/3732",
+                "sub": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+                "vc": {
+                    "@context": [
+                        "https://www.w3.org/2018/credentials/v1",
+                        "https://www.w3.org/2018/credentials/examples/v1"
+                    ],
+                    "type": [
+                        "VerifiableCredential",
+                        "IDCredential"
+                    ],
+                    "credentialSubject": {
+                        "given_name": "Max",
+                        "family_name": "Mustermann",
+                        "birthdate": "1998-01-11",
+                        "address": {
+                            "street_address": "Sandanger 25",
+                            "locality": "Musterstadt",
+                            "postal_code": "123456",
+                            "country": "DE"
+                        }
+                    }
+                }
+            }
+        );
+
+        let presentation_submission = create_presentation_submission(
+            "example_jwt_vc_presentation_submission".to_string(),
+            &presentation_definition,
+            &[credential_data],
+        )
+        .unwrap();
+
+        assert_eq!(
+            json!(presentation_submission),
+            json!(
+                {
+                    "definition_id": "example_jwt_vc",
+                    "id": "example_jwt_vc_presentation_submission",
+                    "descriptor_map": [
+                        {
+                            "id": "id_credential",
+                            "path": "$",
+                            "format": "jwt_vp_json",
+                            "path_nested": {
+                                "path": "$.vp.verifiableCredential[0]",
+                                "format": "jwt_vc_json"
+                            }
+                        }
+                    ]
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn test_create_sd_jwt_presentation_submission() {
+        // With example data from:
+        // https://openid.net/specs/openid-4-verifiable-presentations-1_0-21.html#name-ietf-sd-jwt-vc
+
+        let presentation_definition: PresentationDefinition = serde_json::from_value(json!(
+            {
+                "id": "example_sd_jwt_vc_request",
+                "input_descriptors": [
+                    {
+                        "id": "identity_credential",
+                        "format": {
+                            "vc+sd-jwt": {
+                                "sd-jwt_alg_values": [
+                                    "ES256",
+                                    "ES384"
+                                ],
+                                "kb-jwt_alg_values": [
+                                    "ES256",
+                                    "ES384"
+                                ]
+                            }
+                        },
+                        "constraints": {
+                            "limit_disclosure": "required",
+                            "fields": [
+                                {
+                                    "path": [
+                                        "$.vct"
+                                    ],
+                                    "filter": {
+                                        "type": "string",
+                                        "const": "pid_vc+sd-jwt"
+                                    }
+                                },
+                                {
+                                    "path": [
+                                        "$.family_name"
+                                    ]
+                                },
+                                {
+                                    "path": [
+                                        "$.given_name"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ))
+        .unwrap();
+
+        let credential_data = json!(
+            {
+                "sub": "did:jwk:eyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJraWQiOiJFRUdOOGViWjlxVGRIRlJYSjFwRG1fM25iMllLSk1fWU9sV2QzRG44Z0lNIiwia3R5IjoiT0tQIiwieCI6Ik4tMkgtZlJ1RmlHQy1ON05ET0Zob214T01ZWnVWd29nZF9hYV81S0h1aUkifQ",
+                "id": "urn:uuid:730d0750-d418-430a-85bd-2faca00f2447",
+                "iss": "did:example:123",
+                "nbf": 1741094882,
+                "exp": 1772630882,
+                "vct": "pid_vc+sd-jwt",
+                "iat": 1741094882,
+                "family_name": "Ferris",
+                "given_name": "Crabman"
+            }
+        );
+
+        let presentation_submission = create_sd_jwt_presentation_submission(
+            "example_sd_jwt_vc_presentation_submission".to_string(),
+            &presentation_definition,
+            &[credential_data],
+        )
+        .unwrap();
+
+        assert_eq!(
+            json!(presentation_submission),
+            json!(
+                {
+                    "definition_id": "example_sd_jwt_vc_request",
+                    "id": "example_sd_jwt_vc_presentation_submission",
+                    "descriptor_map": [
+                        {
+                            "id": "identity_credential",
+                            "path": "$",
+                            "format": "vc+sd-jwt"
+                        }
+                    ]
+                }
+            )
+        )
+    }
 }

--- a/oid4vc-manager/src/servers/credential_issuer.rs
+++ b/oid4vc-manager/src/servers/credential_issuer.rs
@@ -147,11 +147,7 @@ async fn token<S: Storage<CFC>, CFC: CredentialFormatCollection>(
     State(credential_issuer_manager): State<CredentialIssuerManager<S, CFC>>,
     Form(token_request): Form<TokenRequest>,
 ) -> impl IntoResponse {
-    match credential_issuer_manager
-        .storage
-        .get_token_response(token_request)
-        .take()
-    {
+    match credential_issuer_manager.storage.get_token_response(token_request) {
         Some(token_response) => (
             StatusCode::OK,
             AppendHeaders([("Cache-Control", "no-store")]),

--- a/oid4vc-manager/tests/oid4vp/implicit.rs
+++ b/oid4vc-manager/tests/oid4vp/implicit.rs
@@ -15,7 +15,7 @@ use oid4vc_manager::{
 use oid4vci::VerifiableCredentialJwt;
 use oid4vp::{
     authorization_request::ClientMetadataParameters,
-    oid4vp::{AuthorizationResponseInput, OID4VP},
+    oid4vp::{AuthorizationResponseInput, PresentationInputType, OID4VP},
     ClaimFormatDesignation, ClaimFormatProperty, PresentationDefinition,
 };
 use serde_json::json;
@@ -176,12 +176,14 @@ async fn test_implicit_flow() {
             .build()
             .unwrap();
 
+    let verifiable_presentation_input = PresentationInputType::Unsigned(verifiable_presentation);
+
     // Generate the authorization_response. It will include both an IdToken and a VpToken.
     let authorization_response: AuthorizationResponse<OID4VP> = provider_manager
         .generate_response(
             &authorization_request,
             AuthorizationResponseInput {
-                verifiable_presentation,
+                verifiable_presentation_input,
                 presentation_submission,
             },
         )

--- a/oid4vc-manager/tests/oid4vp/implicit.rs
+++ b/oid4vc-manager/tests/oid4vp/implicit.rs
@@ -151,6 +151,7 @@ async fn test_implicit_flow() {
 
     // Create presentation submission using the presentation definition and the verifiable credential.
     let presentation_submission = create_presentation_submission(
+        "example_jwt_vc_presentation_submission".to_string(),
         &PRESENTATION_DEFINITION,
         &vec![serde_json::to_value(&verifiable_credential).unwrap()],
     )
@@ -176,7 +177,7 @@ async fn test_implicit_flow() {
             .build()
             .unwrap();
 
-    let verifiable_presentation_input = PresentationInputType::Unsigned(verifiable_presentation);
+    let verifiable_presentation_input = PresentationInputType::Presentation(verifiable_presentation);
 
     // Generate the authorization_response. It will include both an IdToken and a VpToken.
     let authorization_response: AuthorizationResponse<OID4VP> = provider_manager

--- a/oid4vci/src/authorization_details.rs
+++ b/oid4vci/src/authorization_details.rs
@@ -185,6 +185,19 @@ mod tests {
         assert_eq!(
             vec![AuthorizationDetailsObject {
                 r#type: OpenidCredential::Type,
+                locations: None,
+                credential_configuration_or_format: CredentialConfigurationOrFormat::CredentialFormat(
+                    CredentialFormats::VcSdJwt(Parameters {
+                        parameters: ("SD_JWT_VC_example_in_OpenID4VCI".to_string(), None, None).into(),
+                    }),
+                ),
+            }],
+            json_example::<Vec<AuthorizationDetailsObject>>("tests/examples/authorization_details_sd_jwt_vc.json")
+        );
+
+        assert_eq!(
+            vec![AuthorizationDetailsObject {
+                r#type: OpenidCredential::Type,
                 locations: Some(vec!["https://credential-issuer.example.com".parse().unwrap()]),
                 credential_configuration_or_format: CredentialConfigurationOrFormat::CredentialConfigurationId {
                     credential_configuration_id: "UniversityDegreeCredential".to_string(),

--- a/oid4vci/src/authorization_details.rs
+++ b/oid4vci/src/authorization_details.rs
@@ -49,18 +49,7 @@ mod tests {
         w3c_verifiable_credentials::{jwt_vc_json, CredentialSubject},
         Parameters,
     };
-    use serde::de::DeserializeOwned;
-    use serde_json::json;
-    use std::{fs::File, path::Path};
-
-    fn json_example<T>(path: &str) -> T
-    where
-        T: DeserializeOwned,
-    {
-        let file_path = Path::new(path);
-        let file = File::open(file_path).expect("file does not exist");
-        serde_json::from_reader::<_, T>(file).expect("could not parse json")
-    }
+    use serde_json::{from_str, json};
 
     #[test]
     fn test_authorization_details_object_with_format() {
@@ -116,7 +105,10 @@ mod tests {
                     })),
                 }
             }],
-            json_example::<Vec<AuthorizationDetailsObject>>("tests/examples/authorization_details_jwt_vc_json.json")
+            from_str::<Vec<AuthorizationDetailsObject>>(include_str!(
+                "../tests/examples/authorization_details_jwt_vc_json.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -134,7 +126,10 @@ mod tests {
                     })),
                 }
             }],
-            json_example::<Vec<AuthorizationDetailsObject>>("tests/examples/authorization_details_ldp_vc.json")
+            from_str::<Vec<AuthorizationDetailsObject>>(include_str!(
+                "../tests/examples/authorization_details_ldp_vc.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -155,7 +150,10 @@ mod tests {
                     })))),
                 }
             }],
-            json_example::<Vec<AuthorizationDetailsObject>>("tests/examples/authorization_details_mso_mdoc.json")
+            from_str::<Vec<AuthorizationDetailsObject>>(include_str!(
+                "../tests/examples/authorization_details_mso_mdoc.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -177,9 +175,10 @@ mod tests {
                     }
                 }
             ],
-            json_example::<Vec<AuthorizationDetailsObject>>(
-                "tests/examples/authorization_details_multiple_credentials.json"
-            )
+            from_str::<Vec<AuthorizationDetailsObject>>(include_str!(
+                "../tests/examples/authorization_details_multiple_credentials.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -192,7 +191,10 @@ mod tests {
                     }),
                 ),
             }],
-            json_example::<Vec<AuthorizationDetailsObject>>("tests/examples/authorization_details_sd_jwt_vc.json")
+            from_str::<Vec<AuthorizationDetailsObject>>(include_str!(
+                "../tests/examples/authorization_details_sd_jwt_vc.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -204,7 +206,10 @@ mod tests {
                     parameters: None,
                 }
             }],
-            json_example::<Vec<AuthorizationDetailsObject>>("tests/examples/authorization_details_with_as.json")
+            from_str::<Vec<AuthorizationDetailsObject>>(include_str!(
+                "../tests/examples/authorization_details_with_as.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -216,7 +221,8 @@ mod tests {
                     parameters: None,
                 },
             }],
-            json_example::<Vec<AuthorizationDetailsObject>>("tests/examples/authorization_details.json")
+            from_str::<Vec<AuthorizationDetailsObject>>(include_str!("../tests/examples/authorization_details.json"))
+                .unwrap()
         );
     }
 }

--- a/oid4vci/src/credential_format_profiles/ietf_sd_jwt_vc/mod.rs
+++ b/oid4vci/src/credential_format_profiles/ietf_sd_jwt_vc/mod.rs
@@ -1,0 +1,7 @@
+use crate::credential_format;
+
+credential_format!("vc+sd-jwt", VcSdJwt, {
+    vct: String,
+    claims: Option<serde_json::Value>,
+    order: Option<Vec<String>>
+});

--- a/oid4vci/src/credential_format_profiles/ietf_sd_jwt_vc/mod.rs
+++ b/oid4vci/src/credential_format_profiles/ietf_sd_jwt_vc/mod.rs
@@ -1,7 +1,1 @@
-use crate::credential_format;
-
-credential_format!("vc+sd-jwt", VcSdJwt, {
-    vct: String,
-    claims: Option<serde_json::Value>,
-    order: Option<Vec<String>>
-});
+pub mod vc_sd_jwt;

--- a/oid4vci/src/credential_format_profiles/ietf_sd_jwt_vc/vc_sd_jwt.rs
+++ b/oid4vci/src/credential_format_profiles/ietf_sd_jwt_vc/vc_sd_jwt.rs
@@ -1,0 +1,7 @@
+use crate::credential_format;
+
+credential_format!("vc+sd-jwt", VcSdJwt, {
+    vct: String,
+    claims: Option<serde_json::Value>,
+    order: Option<Vec<String>>
+});

--- a/oid4vci/src/credential_format_profiles/mod.rs
+++ b/oid4vci/src/credential_format_profiles/mod.rs
@@ -1,3 +1,4 @@
+pub mod ietf_sd_jwt_vc;
 pub mod iso_mdl;
 pub mod w3c_verifiable_credentials;
 
@@ -8,6 +9,7 @@ use self::{
         jwt_vc_json::JwtVcJson, jwt_vc_json_ld::JwtVcJsonLd, ldp_vc::LdpVc, CredentialSubject,
     },
 };
+use ietf_sd_jwt_vc::VcSdJwt;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -107,6 +109,8 @@ where
     LdpVc(C::Container<LdpVc>),
     #[serde(rename = "mso_mdoc")]
     MsoMdoc(C::Container<MsoMdoc>),
+    #[serde(rename = "vc+sd-jwt")]
+    VcSdJwt(C::Container<VcSdJwt>),
     #[default]
     Unknown,
 }
@@ -132,6 +136,7 @@ where
             CredentialFormats::JwtVcJsonLd(_) => CredentialFormats::JwtVcJsonLd(()),
             CredentialFormats::LdpVc(_) => CredentialFormats::LdpVc(()),
             CredentialFormats::MsoMdoc(_) => CredentialFormats::MsoMdoc(()),
+            CredentialFormats::VcSdJwt(_) => CredentialFormats::VcSdJwt(()),
             CredentialFormats::Unknown => CredentialFormats::Unknown,
         }
     }
@@ -144,6 +149,7 @@ impl CredentialFormats<WithCredential> {
             CredentialFormats::JwtVcJsonLd(credential) => Ok(&credential.credential),
             CredentialFormats::LdpVc(credential) => Ok(&credential.credential),
             CredentialFormats::MsoMdoc(credential) => Ok(&credential.credential),
+            CredentialFormats::VcSdJwt(credential) => Ok(&credential.credential),
             CredentialFormats::Unknown => Err(anyhow::anyhow!("Unknown credential format")),
         }
     }

--- a/oid4vci/src/credential_format_profiles/mod.rs
+++ b/oid4vci/src/credential_format_profiles/mod.rs
@@ -9,7 +9,7 @@ use self::{
         jwt_vc_json::JwtVcJson, jwt_vc_json_ld::JwtVcJsonLd, ldp_vc::LdpVc, CredentialSubject,
     },
 };
-use ietf_sd_jwt_vc::VcSdJwt;
+use ietf_sd_jwt_vc::vc_sd_jwt::VcSdJwt;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/oid4vci/src/credential_format_profiles/w3c_verifiable_credentials/jwt_vc_json.rs
+++ b/oid4vci/src/credential_format_profiles/w3c_verifiable_credentials/jwt_vc_json.rs
@@ -6,7 +6,7 @@ use super::CredentialSubject;
 
 credential_format!("jwt_vc_json", JwtVcJson, {
     credential_definition: CredentialDefinition,
-    order: Option<String>
+    order: Option<Vec<String>>
 });
 
 #[skip_serializing_none]

--- a/oid4vci/src/credential_format_profiles/w3c_verifiable_credentials/jwt_vc_json_ld.rs
+++ b/oid4vci/src/credential_format_profiles/w3c_verifiable_credentials/jwt_vc_json_ld.rs
@@ -6,7 +6,7 @@ use super::CredentialSubject;
 
 credential_format!("jwt_vc_json-ld", JwtVcJsonLd, {
     credential_definition: CredentialDefinition,
-    order: Option<String>
+    order: Option<Vec<String>>
 });
 
 #[skip_serializing_none]

--- a/oid4vci/src/credential_format_profiles/w3c_verifiable_credentials/ldp_vc.rs
+++ b/oid4vci/src/credential_format_profiles/w3c_verifiable_credentials/ldp_vc.rs
@@ -6,7 +6,7 @@ use super::CredentialSubject;
 
 credential_format!("ldp_vc", LdpVc, {
     credential_definition: CredentialDefinition,
-    order: Option<String>
+    order: Option<Vec<String>>
 });
 
 #[skip_serializing_none]

--- a/oid4vci/src/credential_issuer/credential_configurations_supported.rs
+++ b/oid4vci/src/credential_issuer/credential_configurations_supported.rs
@@ -38,22 +38,12 @@ mod tests {
         CredentialFormats, Parameters,
     };
     use jsonwebtoken::Algorithm;
-    use serde::de::DeserializeOwned;
-    use serde_json::json;
-    use std::{collections::HashMap, fs::File, path::Path};
+    use serde_json::{from_str, json};
+    use std::collections::HashMap;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct TestWrapper {
         credential_configurations_supported: HashMap<String, CredentialConfigurationsSupportedObject>,
-    }
-
-    fn json_example<T>(path: &str) -> T
-    where
-        T: DeserializeOwned,
-    {
-        let file_path = Path::new(path);
-        let file = File::open(file_path).expect("file does not exist");
-        serde_json::from_reader::<_, T>(file).expect("could not parse json")
     }
 
     #[test]
@@ -133,7 +123,10 @@ mod tests {
                 .into_iter()
                 .collect()
             },
-            json_example::<TestWrapper>("tests/examples/credential_metadata_jwt_vc_json.json")
+            from_str::<TestWrapper>(include_str!(
+                "../../tests/examples/credential_metadata_jwt_vc_json.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -206,7 +199,7 @@ mod tests {
                 .into_iter()
                 .collect()
             },
-            json_example::<TestWrapper>("tests/examples/credential_metadata_ldp_vc.json")
+            from_str::<TestWrapper>(include_str!("../../tests/examples/credential_metadata_ldp_vc.json")).unwrap()
         );
 
         assert_eq!(
@@ -286,7 +279,7 @@ mod tests {
                 .into_iter()
                 .collect()
             },
-            json_example::<TestWrapper>("tests/examples/credential_metadata_mso_mdoc.json")
+            from_str::<TestWrapper>(include_str!("../../tests/examples/credential_metadata_mso_mdoc.json")).unwrap()
         );
 
         assert_eq!(
@@ -354,7 +347,7 @@ mod tests {
                 .into_iter()
                 .collect()
             },
-            json_example::<TestWrapper>("tests/examples/credential_metadata_sd_jwt_vc.json")
+            from_str::<TestWrapper>(include_str!("../../tests/examples/credential_metadata_sd_jwt_vc.json")).unwrap()
         );
     }
 }

--- a/oid4vci/src/credential_issuer/credential_configurations_supported.rs
+++ b/oid4vci/src/credential_issuer/credential_configurations_supported.rs
@@ -288,5 +288,73 @@ mod tests {
             },
             json_example::<TestWrapper>("tests/examples/credential_metadata_mso_mdoc.json")
         );
+
+        assert_eq!(
+            TestWrapper {
+                credential_configurations_supported: vec![(
+                    "SD_JWT_VC_example_in_OpenID4VCI".to_string(),
+                    CredentialConfigurationsSupportedObject {
+                        credential_format: CredentialFormats::VcSdJwt(Parameters {
+                            parameters: (
+                                "SD_JWT_VC_example_in_OpenID4VCI".to_string(),
+                                Some(json!({
+                                  "given_name": {
+                                    "display": [
+                                      {
+                                        "name": "Given Name",
+                                        "locale": "en-US"
+                                      },
+                                      {
+                                        "name": "Vorname",
+                                        "locale": "de-DE"
+                                      }
+                                    ]
+                                  },
+                                  "family_name": {
+                                    "display": [
+                                      {
+                                        "name": "Surname",
+                                        "locale": "en-US"
+                                      },
+                                      {
+                                        "name": "Nachname",
+                                        "locale": "de-DE"
+                                      }
+                                    ]
+                                  },
+                                  "email": {},
+                                  "phone_number": {},
+                                  "address": {
+                                    "street_address": {},
+                                    "locality": {},
+                                    "region": {},
+                                    "country": {}
+                                  },
+                                  "birthdate": {},
+                                  "is_over_18": {},
+                                  "is_over_21": {},
+                                  "is_over_65": {}
+                                })),
+                                None
+                            )
+                                .into()
+                        }),
+                        scope: Some("SD_JWT_VC_example_in_OpenID4VCI".to_string()),
+                        cryptographic_binding_methods_supported: vec!["jwk".to_string()],
+                        credential_signing_alg_values_supported: vec!["ES256".to_string()],
+                        proof_types_supported: HashMap::new(),
+                        display: vec![json!(        {
+                          "name": "IdentityCredential",
+                          "locale": "en-US",
+                          "background_color": "#12107c",
+                          "text_color": "#FFFFFF"
+                        })]
+                    }
+                )]
+                .into_iter()
+                .collect()
+            },
+            json_example::<TestWrapper>("tests/examples/credential_metadata_sd_jwt_vc.json")
+        );
     }
 }

--- a/oid4vci/src/credential_issuer/credential_issuer_metadata.rs
+++ b/oid4vci/src/credential_issuer/credential_issuer_metadata.rs
@@ -52,18 +52,7 @@ mod tests {
         ProofType,
     };
     use jsonwebtoken::Algorithm;
-    use serde::de::DeserializeOwned;
-    use serde_json::json;
-    use std::{fs::File, path::Path};
-
-    fn json_example<T>(path: &str) -> T
-    where
-        T: DeserializeOwned,
-    {
-        let file_path = Path::new(path);
-        let file = File::open(file_path).expect("file does not exist");
-        serde_json::from_reader::<_, T>(file).expect("could not parse json")
-    }
+    use serde_json::{from_str, json};
 
     #[test]
     fn test_oid4vci_examples() {
@@ -172,7 +161,10 @@ mod tests {
                 .into_iter()
                 .collect(),
             },
-            json_example::<CredentialIssuerMetadata>("tests/examples/credential_issuer_metadata_jwt_vc_json.json")
+            from_str::<CredentialIssuerMetadata>(include_str!(
+                "../../tests/examples/credential_issuer_metadata_jwt_vc_json.json"
+            ))
+            .unwrap()
         );
     }
 }

--- a/oid4vci/src/credential_offer.rs
+++ b/oid4vci/src/credential_offer.rs
@@ -105,20 +105,8 @@ pub struct Grants {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::File, path::Path};
-
     use super::*;
-    use serde::de::DeserializeOwned;
-    use serde_json::json;
-
-    fn json_example<T>(path: &str) -> T
-    where
-        T: DeserializeOwned,
-    {
-        let file_path = Path::new(path);
-        let file = File::open(file_path).expect("file does not exist");
-        serde_json::from_reader::<_, T>(file).expect("could not parse json")
-    }
+    use serde_json::{from_str, json};
 
     #[test]
     fn test_credential_offer_serde() {
@@ -180,7 +168,8 @@ mod tests {
                     })
                 })
             },
-            json_example::<CredentialOfferParameters>("tests/examples/credential_offer_by_reference.json")
+            from_str::<CredentialOfferParameters>(include_str!("../tests/examples/credential_offer_by_reference.json"))
+                .unwrap()
         );
 
         assert_eq!(
@@ -203,7 +192,10 @@ mod tests {
                     })
                 })
             },
-            json_example::<CredentialOfferParameters>("tests/examples/credential_offer_multiple_credentials.json")
+            from_str::<CredentialOfferParameters>(include_str!(
+                "../tests/examples/credential_offer_multiple_credentials.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -225,7 +217,10 @@ mod tests {
                     })
                 })
             },
-            json_example::<CredentialOfferParameters>("tests/examples/credential_offer_pre-authz_code.json")
+            from_str::<CredentialOfferParameters>(include_str!(
+                "../tests/examples/credential_offer_pre-authz_code.json"
+            ))
+            .unwrap()
         );
     }
 }

--- a/oid4vci/src/credential_request.rs
+++ b/oid4vci/src/credential_request.rs
@@ -288,5 +288,17 @@ mod tests {
             },
             json_example::<CredentialRequest>("tests/examples/credential_request_ldp_vc.json")
         );
+
+        assert_eq!(
+            CredentialRequest {
+                credential_format: CredentialFormats::VcSdJwt(Parameters {
+                    parameters: ("SD_JWT_VC_example_in_OpenID4VCI".to_string(), None, None).into(),
+                }),
+                proof: Some(KeyProofType::Jwt {
+                    jwt: "eyJ0eXAiOiJvcGVuaWQ0dmNpLXByb29mK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJ4IjoiblVXQW9BdjNYWml0aDhFN2kxOU9kYXhPTFlGT3dNLVoyRXVNMDJUaXJUNCIsInkiOiJIc2tIVThCalVpMVU5WHFpN1N3bWo4Z3dBS18weGtjRGpFV183MVNvc0VZIn19.eyJhdWQiOiJodHRwczovL2NyZWRlbnRpYWwtaXNzdWVyLmV4YW1wbGUuY29tIiwiaWF0IjoxNzAxOTYwNDQ0LCJub25jZSI6IkxhclJHU2JtVVBZdFJZTzZCUTR5bjgifQ.-a3EDsxClUB4O3LeDD5DVGEnNMT01FCQW4P6-2-BNBqc_Zxf0Qw4CWayLEpqkAomlkLb9zioZoipdP-jvh1WlA".to_string()
+                })
+            },
+            json_example::<CredentialRequest>("tests/examples/credential_request_sd_jwt_vc.json")
+        );
     }
 }

--- a/oid4vci/src/credential_request.rs
+++ b/oid4vci/src/credential_request.rs
@@ -38,18 +38,7 @@ mod tests {
         },
         CredentialFormats, Parameters,
     };
-    use serde::de::DeserializeOwned;
-    use serde_json::json;
-    use std::{fs::File, path::Path};
-
-    fn json_example<T>(path: &str) -> T
-    where
-        T: DeserializeOwned,
-    {
-        let file_path = Path::new(path);
-        let file = File::open(file_path).expect("file does not exist");
-        serde_json::from_reader::<_, T>(file).expect("could not parse json")
-    }
+    use serde_json::{from_str, json};
 
     #[test]
     fn test_credential_request_serde_jwt_vc_json() {
@@ -192,7 +181,10 @@ mod tests {
                     jwt: "eyJraWQiOiJkaWQ6ZXhhbXBsZ...KPxgihac0aW9EkL1nOzM".to_string()
                 })
             },
-            json_example::<CredentialRequest>("tests/examples/credential_request_iso_mdl_with_claims.json")
+            from_str::<CredentialRequest>(include_str!(
+                "../tests/examples/credential_request_iso_mdl_with_claims.json"
+            ))
+            .unwrap()
         );
 
         assert_eq!(
@@ -224,7 +216,8 @@ mod tests {
                     jwt: "eyJraWQiOiJkaWQ6ZXhhbXBsZ...KPxgihac0aW9EkL1nOzM".to_string()
                 })
             },
-            json_example::<CredentialRequest>("tests/examples/credential_request_jwt_vc_json-ld.json")
+            from_str::<CredentialRequest>(include_str!("../tests/examples/credential_request_jwt_vc_json-ld.json"))
+                .unwrap()
         );
 
         assert_eq!(
@@ -252,9 +245,8 @@ mod tests {
                     jwt: "eyJraWQiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEva2V5cy8xIiwiYWxnIjoiRVMyNTYiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJzNkJoZFJrcXQzIiwiYXVkIjoiaHR0cHM6Ly9zZXJ2ZXIuZXhhbXBsZS5jb20iLCJpYXQiOiIyMDE4LTA5LTE0VDIxOjE5OjEwWiIsIm5vbmNlIjoidFppZ25zbkZicCJ9.ewdkIkPV50iOeBUqMXCC_aZKPxgihac0aW9EkL1nOzM".to_string()
                 })
             },
-            json_example::<CredentialRequest>(
-                "tests/examples/credential_request_jwt_vc_json_with_claims.json"
-            )
+            from_str::<CredentialRequest>(include_str!("../tests/examples/credential_request_jwt_vc_json_with_claims.json"))
+                .unwrap()
         );
 
         assert_eq!(
@@ -286,7 +278,7 @@ mod tests {
                     jwt: "eyJraWQiOiJkaWQ6ZXhhbXBsZ...KPxgihac0aW9EkL1nOzM".to_string()
                 })
             },
-            json_example::<CredentialRequest>("tests/examples/credential_request_ldp_vc.json")
+            from_str::<CredentialRequest>(include_str!("../tests/examples/credential_request_ldp_vc.json")).unwrap()
         );
 
         assert_eq!(
@@ -298,7 +290,8 @@ mod tests {
                     jwt: "eyJ0eXAiOiJvcGVuaWQ0dmNpLXByb29mK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJ4IjoiblVXQW9BdjNYWml0aDhFN2kxOU9kYXhPTFlGT3dNLVoyRXVNMDJUaXJUNCIsInkiOiJIc2tIVThCalVpMVU5WHFpN1N3bWo4Z3dBS18weGtjRGpFV183MVNvc0VZIn19.eyJhdWQiOiJodHRwczovL2NyZWRlbnRpYWwtaXNzdWVyLmV4YW1wbGUuY29tIiwiaWF0IjoxNzAxOTYwNDQ0LCJub25jZSI6IkxhclJHU2JtVVBZdFJZTzZCUTR5bjgifQ.-a3EDsxClUB4O3LeDD5DVGEnNMT01FCQW4P6-2-BNBqc_Zxf0Qw4CWayLEpqkAomlkLb9zioZoipdP-jvh1WlA".to_string()
                 })
             },
-            json_example::<CredentialRequest>("tests/examples/credential_request_sd_jwt_vc.json")
+            from_str::<CredentialRequest>(include_str!("../tests/examples/credential_request_sd_jwt_vc.json")).unwrap()
+
         );
     }
 }

--- a/oid4vci/tests/examples/authorization_details_sd_jwt_vc.json
+++ b/oid4vci/tests/examples/authorization_details_sd_jwt_vc.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "openid_credential",
+    "format": "vc+sd-jwt",
+    "vct": "SD_JWT_VC_example_in_OpenID4VCI"
+  }
+]

--- a/oid4vci/tests/examples/credential_metadata_sd_jwt_vc.json
+++ b/oid4vci/tests/examples/credential_metadata_sd_jwt_vc.json
@@ -1,0 +1,57 @@
+{
+  "credential_configurations_supported": {
+    "SD_JWT_VC_example_in_OpenID4VCI": {
+      "format": "vc+sd-jwt",
+      "scope": "SD_JWT_VC_example_in_OpenID4VCI",
+      "cryptographic_binding_methods_supported": ["jwk"],
+      "credential_signing_alg_values_supported": ["ES256"],
+      "display": [
+        {
+          "name": "IdentityCredential",
+          "locale": "en-US",
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "vct": "SD_JWT_VC_example_in_OpenID4VCI",
+      "claims": {
+        "given_name": {
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            },
+            {
+              "name": "Vorname",
+              "locale": "de-DE"
+            }
+          ]
+        },
+        "family_name": {
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            },
+            {
+              "name": "Nachname",
+              "locale": "de-DE"
+            }
+          ]
+        },
+        "email": {},
+        "phone_number": {},
+        "address": {
+          "street_address": {},
+          "locality": {},
+          "region": {},
+          "country": {}
+        },
+        "birthdate": {},
+        "is_over_18": {},
+        "is_over_21": {},
+        "is_over_65": {}
+      }
+    }
+  }
+}

--- a/oid4vci/tests/examples/credential_request_sd_jwt_vc.json
+++ b/oid4vci/tests/examples/credential_request_sd_jwt_vc.json
@@ -1,0 +1,8 @@
+{
+  "format": "vc+sd-jwt",
+  "vct": "SD_JWT_VC_example_in_OpenID4VCI",
+  "proof": {
+    "proof_type": "jwt",
+    "jwt": "eyJ0eXAiOiJvcGVuaWQ0dmNpLXByb29mK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJ4IjoiblVXQW9BdjNYWml0aDhFN2kxOU9kYXhPTFlGT3dNLVoyRXVNMDJUaXJUNCIsInkiOiJIc2tIVThCalVpMVU5WHFpN1N3bWo4Z3dBS18weGtjRGpFV183MVNvc0VZIn19.eyJhdWQiOiJodHRwczovL2NyZWRlbnRpYWwtaXNzdWVyLmV4YW1wbGUuY29tIiwiaWF0IjoxNzAxOTYwNDQ0LCJub25jZSI6IkxhclJHU2JtVVBZdFJZTzZCUTR5bjgifQ.-a3EDsxClUB4O3LeDD5DVGEnNMT01FCQW4P6-2-BNBqc_Zxf0Qw4CWayLEpqkAomlkLb9zioZoipdP-jvh1WlA"
+  }
+}

--- a/oid4vp/src/authorization_request.rs
+++ b/oid4vp/src/authorization_request.rs
@@ -128,21 +128,9 @@ impl AuthorizationRequestBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::File, path::Path};
-
-    use jsonwebtoken::Algorithm;
-    use serde::de::DeserializeOwned;
-
     use super::*;
-
-    fn json_example<T>(path: &str) -> T
-    where
-        T: DeserializeOwned,
-    {
-        let file_path = Path::new(path);
-        let file = File::open(file_path).expect("file does not exist");
-        serde_json::from_reader::<_, T>(file).expect("could not parse json")
-    }
+    use jsonwebtoken::Algorithm;
+    use serde_json::from_str;
 
     #[test]
     fn test_client_id_scheme() {
@@ -226,7 +214,10 @@ mod tests {
                     other: HashMap::from_iter(vec![("application_type".to_string(), serde_json::json!("web"))]),
                 }),
             },
-            json_example::<ExampleAuthorizationRequest>("tests/examples/client_metadata/client_client_id_did.json")
+            from_str::<ExampleAuthorizationRequest>(include_str!(
+                "../tests/examples/client_metadata/client_client_id_did.json"
+            ))
+            .unwrap()
         );
     }
 }

--- a/oid4vp/src/oid4vp.rs
+++ b/oid4vp/src/oid4vp.rs
@@ -71,10 +71,10 @@ impl Extension for OID4VP {
 
         let mut jwts = vec![];
         match &user_input.verifiable_presentation_input {
-            PresentationInputType::Unsigned(verifiable_presentation) => {
+            PresentationInputType::Presentation(verifiable_presentation) => {
                 let vp_token = VpToken::builder()
                     .iss(subject_identifier.clone())
-                    .sub(subject_identifier.clone())
+                    .sub(subject_identifier)
                     .aud(client_id)
                     .nonce(extension_parameters.nonce.to_owned())
                     // TODO: make this configurable.
@@ -93,7 +93,7 @@ impl Extension for OID4VP {
 
                 jwts.push(jwt);
             }
-            PresentationInputType::Signed(jwt) => {
+            PresentationInputType::SdJwtVc(jwt) => {
                 jwts.push(jwt.to_owned());
             }
         }
@@ -243,6 +243,6 @@ pub struct AuthorizationResponseInput {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum PresentationInputType {
-    Unsigned(Presentation<Jwt>),
-    Signed(String),
+    Presentation(Presentation<Jwt>),
+    SdJwtVc(String),
 }


### PR DESCRIPTION
# Description of change
Adds initial support for SD-JWT

This PR does NOT include Key Binding validation. 

## Links to any relevant issues
n/a

## How the change has been tested
Added several tests:
- `test_create_presentation_submission`
- `test_create_sd_jwt_presentation_submission`
- deserialization test with fixtures coming from [here](https://github.com/openid/OpenID4VCI/blob/80b2214814106e55e5fd09af3415ba4fc124b6be/examples/credential_request_sd_jwt_vc.json)
  - `oid4vci/tests/examples/authorization_details_sd_jwt_vc.json`
  - `oid4vci/tests/examples/credential_metadata_sd_jwt_vc.json`
  - `oid4vci/tests/examples/credential_request_sd_jwt_vc.json`

This branch has been included in [this PR](https://github.com/impierce/identity-wallet/pull/387) in UniMe. More testing validations can be found there.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes