### PR TITLE
fix: change request objects `typ` to `oauth-authz-req+jwt`

### DIFF
--- a/siopv2/src/relying_party.rs
+++ b/siopv2/src/relying_party.rs
@@ -36,13 +36,15 @@ impl RelyingParty {
         authorization_request: &AuthorizationRequest<Object<E>>,
         signing_algorithm: impl TryInto<Algorithm>,
     ) -> Result<String> {
+        let mut header = Header::new(
+            signing_algorithm
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("Invalid signing algorithm."))?,
+        );
+        header.typ = Some("oauth-authz-req+jwt".to_string());
         jwt::encode(
             self.subject.clone(),
-            Header::new(
-                signing_algorithm
-                    .try_into()
-                    .map_err(|_| anyhow::anyhow!("Invalid signing algorithm."))?,
-            ),
+            header,
             authorization_request,
             &self.default_subject_syntax_type.to_string(),
         )


### PR DESCRIPTION
# Description of change
Updates the request object `typ` header field to `oauth-authz-req+jwt`.

As described here: https://www.rfc-editor.org/rfc/rfc9101.html#section-10.8-3

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes