### PR TITLE
fix: make `proof_types_supported` requirement optional

### DIFF
--- a/oid4vci/Cargo.toml
+++ b/oid4vci/Cargo.toml
@@ -28,4 +28,5 @@ serde_with.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
+oid4vc-core = { path = "../oid4vc-core", features = ["test-utils"] }
 wiremock = "0.5"

--- a/oid4vci/src/wallet/mod.rs
+++ b/oid4vci/src/wallet/mod.rs
@@ -187,7 +187,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
                 "The Credential Issuer does not support JWT proof types"
             ))?;
 
-        // Return the first signin algorithm that matches any of the Credential Issuer's supported signing algorithms.
+        // Return the first signing algorithm that matches any of the Credential Issuer's supported signing algorithms.
         self.proof_signing_alg_values_supported
             .iter()
             .find(|supported_algorithm| {


### PR DESCRIPTION
# Description of change
Prior to this PR, the Wallet always expects the Credential Issuer to supply the `proof_types_supported` parameter to the Credential Configuration in its Credential Issuer Metadata. However, `proof_types_supported` is an optional field hence why this fix was needed. 

In this update, the Wallet will choose its own preferred signing algorithm to sign the Proof if there is no `proof_types_supported` parameter present in the Credential Issuer Metadata. Only when there is a `proof_types_supported` parameter present AND the Wallet can not match it to its own supported signing algorithm it will throw an error. 

If the Wallet can make a match, then it will use the matching signing algorithm to sign the Proof as usual.

## Links to any relevant issues
https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-13.html#section-7.2-2.2.1

## How the change has been tested
Added four unit tests:
```rust
select_signing_algorithm_returns_first_supported_signing_algorithm_when_no_proof_types_supported
select_signing_algorithm_returns_error_when_issuers_supported_proof_type_is_not_supported
select_signing_algorithm_returns_error_when_it_cannot_find_matching_signing_algorithm
select_signing_algorithm_returns_matching_signing_algorithm
```

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes