### PR TITLE
fix: pop trailing slash when requesting Issuer metadata

### DIFF
--- a/oid4vci/src/wallet/mod.rs
+++ b/oid4vci/src/wallet/mod.rs
@@ -79,8 +79,8 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
         // TODO(NGDIL): remove this NGDIL specific code. This is a temporary fix to get the authorization server metadata.
         oauth_authorization_server_endpoint
             .path_segments_mut()
-            .map_err(|_| anyhow::anyhow!("unable to parse credential issuer url"))
-            .unwrap()
+            .map_err(|_| anyhow::anyhow!("unable to parse credential issuer url"))?
+            .pop_if_empty()
             .push(".well-known")
             .push("oauth-authorization-server");
 
@@ -103,6 +103,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
         openid_credential_issuer_endpoint
             .path_segments_mut()
             .map_err(|_| anyhow::anyhow!("unable to parse credential issuer url"))?
+            .pop_if_empty()
             .push(".well-known")
             .push("openid-credential-issuer");
 
@@ -365,6 +366,10 @@ pub mod tests {
     use crate::proof::KeyProofMetadata;
     use oid4vc_core::test_utils::TestSubject;
     use std::{collections::HashMap, sync::Arc};
+    use wiremock::{
+        matchers::{method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
 
     #[test]
     fn select_signing_algorithm_returns_first_supported_signing_algorithm_when_no_proof_types_supported() {
@@ -464,5 +469,71 @@ pub mod tests {
             .unwrap();
 
         assert_eq!(signing_algorithm, Algorithm::EdDSA);
+    }
+
+    #[tokio::test]
+    async fn wallet_successfully_retrieves_authorization_server_metadata() {
+        // Create a new Wallet.
+        let wallet: Wallet = Wallet::new(
+            Arc::new(TestSubject::default()),
+            vec!["did:test"],
+            vec![Algorithm::EdDSA],
+        )
+        .unwrap();
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/some/path/.well-known/oauth-authorization-server"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(AuthorizationServerMetadata::default()))
+            .mount(&mock_server)
+            .await;
+
+        // Assert that the Wallet can get the Authorization Server Metadata from the Credential Issuer URL with or without a trailing slash.
+        let credential_issuer_url = format!("{}/some/path/", mock_server.uri()).parse().unwrap();
+        assert!(wallet
+            .get_authorization_server_metadata(credential_issuer_url)
+            .await
+            .is_ok());
+
+        let credential_issuer_url = format!("{}/some/path", mock_server.uri()).parse().unwrap();
+        assert!(wallet
+            .get_authorization_server_metadata(credential_issuer_url)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn wallet_successfully_retrieves_credential_issuer_metadata() {
+        // Create a new Wallet.
+        let wallet: Wallet = Wallet::new(
+            Arc::new(TestSubject::default()),
+            vec!["did:test"],
+            vec![Algorithm::EdDSA],
+        )
+        .unwrap();
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/some/path/.well-known/openid-credential-issuer"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(CredentialIssuerMetadata::<CredentialFormats>::default()),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // Assert that the Wallet can get the Credential Issuer Metadata from the Credential Issuer URL with or without a trailing slash.
+        let credential_issuer_url = format!("{}/some/path/", mock_server.uri()).parse().unwrap();
+        assert!(wallet
+            .get_credential_issuer_metadata(credential_issuer_url)
+            .await
+            .is_ok());
+
+        let credential_issuer_url = format!("{}/some/path", mock_server.uri()).parse().unwrap();
+        assert!(wallet
+            .get_credential_issuer_metadata(credential_issuer_url)
+            .await
+            .is_ok());
     }
 }


### PR DESCRIPTION
# Description of change
See https://github.com/impierce/identity-wallet/issues/523

## Links to any relevant issues
- https://github.com/impierce/identity-wallet/issues/523

## How the change has been tested
Two unit tests have been added:
* `wallet_successfully_retrieves_authorization_server_metadata`
* `wallet_successfully_retrieves_credential_issuer_metadata`

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes