### PR TITLE
fix: remove extra quotation marks from credential offer URIs

### DIFF
--- a/oid4vc-core/src/lib.rs
+++ b/oid4vc-core/src/lib.rs
@@ -12,7 +12,6 @@ use rand::{distributions::Alphanumeric, Rng};
 pub use rfc7519_claims::RFC7519Claims;
 use serde::Serialize;
 pub use subject_syntax_type::{DidMethod, SubjectSyntaxType};
-use url::Url;
 
 pub type JsonObject = serde_json::Map<String, serde_json::Value>;
 
@@ -43,11 +42,6 @@ pub fn to_query_value<T: Serialize>(value: &T) -> anyhow::Result<String> {
     serde_json::to_string(value)
         .map(|s| s.chars().filter(|c| !c.is_whitespace()).collect::<String>())
         .map_err(|e| e.into())
-}
-
-// Helper to skip JSON serialization for a URL.
-pub fn url_to_query_value(url: &Url) -> anyhow::Result<String> {
-    Ok(url.to_string())
 }
 
 pub fn generate_authorization_code(length: usize) -> String {

--- a/oid4vc-core/src/lib.rs
+++ b/oid4vc-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod openid4vc_extension;
 pub mod rfc7519_claims;
 pub mod scope;
 pub mod subject_syntax_type;
+
 pub use authentication::{sign::Sign, subject::Subject, validator::Validator, verify::Verify};
 use rand::{distributions::Alphanumeric, Rng};
 pub use rfc7519_claims::RFC7519Claims;

--- a/oid4vc-core/src/lib.rs
+++ b/oid4vc-core/src/lib.rs
@@ -7,12 +7,12 @@ pub mod openid4vc_extension;
 pub mod rfc7519_claims;
 pub mod scope;
 pub mod subject_syntax_type;
-
 pub use authentication::{sign::Sign, subject::Subject, validator::Validator, verify::Verify};
 use rand::{distributions::Alphanumeric, Rng};
 pub use rfc7519_claims::RFC7519Claims;
 use serde::Serialize;
 pub use subject_syntax_type::{DidMethod, SubjectSyntaxType};
+use url::Url;
 
 pub type JsonObject = serde_json::Map<String, serde_json::Value>;
 
@@ -43,6 +43,11 @@ pub fn to_query_value<T: Serialize>(value: &T) -> anyhow::Result<String> {
     serde_json::to_string(value)
         .map(|s| s.chars().filter(|c| !c.is_whitespace()).collect::<String>())
         .map_err(|e| e.into())
+}
+
+// Helper to skip JSON serialization for a URL.
+pub fn url_to_query_value(url: &Url) -> anyhow::Result<String> {
+    Ok(url.to_string())
 }
 
 pub fn generate_authorization_code(length: usize) -> String {

--- a/oid4vci/src/credential_offer.rs
+++ b/oid4vci/src/credential_offer.rs
@@ -78,7 +78,7 @@ impl std::fmt::Display for CredentialOffer {
         match self {
             CredentialOffer::CredentialOfferUri(uri) => {
                 let mut url = Url::parse("openid-credential-offer://").map_err(|_| std::fmt::Error)?;
-                url.query_pairs_mut().append_pair("credential_offer_uri", &uri.as_ref());
+                url.query_pairs_mut().append_pair("credential_offer_uri", uri.as_ref());
                 write!(f, "{}", url)
             }
             CredentialOffer::CredentialOffer(offer) => {

--- a/oid4vci/src/credential_offer.rs
+++ b/oid4vci/src/credential_offer.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use oid4vc_core::{to_query_value, JsonObject};
+use oid4vc_core::{to_query_value, url_to_query_value, JsonObject};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -80,7 +80,7 @@ impl std::fmt::Display for CredentialOffer {
                 let mut url = Url::parse("openid-credential-offer://").map_err(|_| std::fmt::Error)?;
                 url.query_pairs_mut().append_pair(
                     "credential_offer_uri",
-                    &to_query_value(uri).map_err(|_| std::fmt::Error)?,
+                    &url_to_query_value(uri).map_err(|_| std::fmt::Error)?,
                 );
                 write!(f, "{}", url)
             }

--- a/oid4vci/src/credential_offer.rs
+++ b/oid4vci/src/credential_offer.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use oid4vc_core::{to_query_value, url_to_query_value, JsonObject};
+use oid4vc_core::{to_query_value, JsonObject};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -78,10 +78,8 @@ impl std::fmt::Display for CredentialOffer {
         match self {
             CredentialOffer::CredentialOfferUri(uri) => {
                 let mut url = Url::parse("openid-credential-offer://").map_err(|_| std::fmt::Error)?;
-                url.query_pairs_mut().append_pair(
-                    "credential_offer_uri",
-                    &url_to_query_value(uri).map_err(|_| std::fmt::Error)?,
-                );
+                url.query_pairs_mut()
+                    .append_pair("credential_offer_uri", &uri.to_string());
                 write!(f, "{}", url)
             }
             CredentialOffer::CredentialOffer(offer) => {

--- a/oid4vci/src/credential_offer.rs
+++ b/oid4vci/src/credential_offer.rs
@@ -78,8 +78,7 @@ impl std::fmt::Display for CredentialOffer {
         match self {
             CredentialOffer::CredentialOfferUri(uri) => {
                 let mut url = Url::parse("openid-credential-offer://").map_err(|_| std::fmt::Error)?;
-                url.query_pairs_mut()
-                    .append_pair("credential_offer_uri", &uri.to_string());
+                url.query_pairs_mut().append_pair("credential_offer_uri", &uri.as_ref());
                 write!(f, "{}", url)
             }
             CredentialOffer::CredentialOffer(offer) => {


### PR DESCRIPTION
# Description of change
Credential offer URIs were being wrapped with extra quotation marks (`%22`) when serialized, causing issues parsing this. This bug occurred because URLs were being JSON-serialized, which adds quotes around string values. The change is a simple one involving chanigng the `Display` implementation for `CredentialOffer::CredentialOfferUri` to use direct string conversion (`uri.as_ref()`) instead of JSON serialization (`to_query_value()`)

## Links to any relevant issues
fixes bug from ssi-agent's [issue #194](https://github.com/impierce/ssi-agent/issues/194)

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes