### PR TITLE
build: pin identity dependencies to v1.6.0-beta.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
     "oid4vp",
     "siopv2",
     "dif-presentation-exchange",
-    "oid4vc-manager"
+    "oid4vc-manager",
 ]
 
 [workspace.package]
@@ -27,15 +27,23 @@ repository = "https://github.com/impierce/openid4vc"
 chrono = "0.4"
 getset = "0.1"
 http = "1.3.1"
-identity_core = { git  = "https://github.com/iotaledger/identity", tag = "v1.6.0-alpha.5" }
-identity_credential = { git  = "https://github.com/iotaledger/identity", tag = "v1.6.0-alpha.5", default-features = false, features = ["validator", "credential", "presentation", "sd-jwt-vc"] }
+identity_core = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.3" }
+identity_credential = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.3", default-features = false, features = [
+    "validator",
+    "credential",
+    "presentation",
+    "sd-jwt-vc",
+] }
 is_empty = "0.2"
 jsonwebtoken = "9.3"
 monostate = "0.1"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = [
+    "json",
+    "rustls-tls",
+] }
 reqwest-middleware = "0.2"
 reqwest-retry = "0.3"
-serde = { version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
 serde_with = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
 serde_with = "3.0"
-tokio = { version = "1.43", features = ["rt", "macros", "rt-multi-thread"] }
+tokio = { version = "1.43.0", features = ["rt", "macros", "rt-multi-thread"] }
 thiserror = "1.0"
 url = { version = "2", features = ["serde"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
 serde_with = "3.0"
-tokio = { version = "1.26.0", features = ["rt", "macros", "rt-multi-thread"] }
+tokio = { version = "1.44.2", features = ["rt", "macros", "rt-multi-thread"] }
 thiserror = "1.0"
 url = { version = "2", features = ["serde"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ repository = "https://github.com/impierce/openid4vc"
 chrono = "0.4"
 getset = "0.1"
 http = "1.3.1"
-identity_core = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.3" }
-identity_credential = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.3", default-features = false, features = [
+identity_core = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.2" }
+identity_credential = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.2", default-features = false, features = [
     "validator",
     "credential",
     "presentation",
@@ -47,7 +47,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
 serde_with = "3.0"
-tokio = { version = "1.44.2", features = ["rt", "macros", "rt-multi-thread"] }
+tokio = { version = "1.43", features = ["rt", "macros", "rt-multi-thread"] }
 thiserror = "1.0"
 url = { version = "2", features = ["serde"] }
 

--- a/oid4vc-core/src/subject_syntax_type.rs
+++ b/oid4vc-core/src/subject_syntax_type.rs
@@ -27,7 +27,7 @@ impl Display for SubjectSyntaxType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SubjectSyntaxType::JwkThumbprint => write!(f, "urn:ietf:params:oauth:jwk-thumbprint"),
-            SubjectSyntaxType::Did(did_method) => write!(f, "{}", did_method),
+            SubjectSyntaxType::Did(did_method) => write!(f, "{did_method}"),
         }
     }
 }

--- a/oid4vc-manager/src/managers/presentation.rs
+++ b/oid4vc-manager/src/managers/presentation.rs
@@ -26,7 +26,7 @@ pub fn create_presentation_submission(
                     path: "$".to_string(),
                     path_nested: Some(PathNested {
                         id: None,
-                        path: format!("$.vp.verifiableCredential[{}]", index),
+                        path: format!("$.vp.verifiableCredential[{index}]"),
                         format: ClaimFormatDesignation::JwtVcJson,
                         path_nested: None,
                     }),

--- a/oid4vci/src/credential_offer.rs
+++ b/oid4vci/src/credential_offer.rs
@@ -79,13 +79,13 @@ impl std::fmt::Display for CredentialOffer {
             CredentialOffer::CredentialOfferUri(uri) => {
                 let mut url = Url::parse("openid-credential-offer://").map_err(|_| std::fmt::Error)?;
                 url.query_pairs_mut().append_pair("credential_offer_uri", uri.as_ref());
-                write!(f, "{}", url)
+                write!(f, "{url}")
             }
             CredentialOffer::CredentialOffer(offer) => {
                 let mut url = Url::parse("openid-credential-offer://").map_err(|_| std::fmt::Error)?;
                 url.query_pairs_mut()
                     .append_pair("credential_offer", &to_query_value(offer).map_err(|_| std::fmt::Error)?);
-                write!(f, "{}", url)
+                write!(f, "{url}")
             }
         }
     }

--- a/oid4vci/src/errors.rs
+++ b/oid4vci/src/errors.rs
@@ -44,7 +44,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Error: {:?}", self.error)?;
         if let Some(desc) = &self.error_description {
-            write!(f, " - {}", desc)?;
+            write!(f, " - {desc}")?;
         }
         Ok(())
     }


### PR DESCRIPTION
# Description of change
pinned identity dependencies to v.1.6.0-beta.2 - had to update tokio dependencies to 1.43 to fix conflicts which arose as a result of the identity bump. 

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes