### PR TITLE
fix: change proof signing algorithms type from `Algorithm` to `String`

### DIFF
--- a/oid4vci/src/credential_issuer/credential_configurations_supported.rs
+++ b/oid4vci/src/credential_issuer/credential_configurations_supported.rs
@@ -83,7 +83,6 @@ mod tests {
         w3c_verifiable_credentials::{jwt_vc_json, ldp_vc, CredentialSubject},
         CredentialFormats, Parameters,
     };
-    use jsonwebtoken::Algorithm;
     use oid4vc_core::claim_path_pointer::ClaimPathElement;
     use serde_json::{from_str, json};
     use std::collections::HashMap;
@@ -121,7 +120,7 @@ mod tests {
                         proof_types_supported: vec![(
                             ProofType::Jwt,
                             KeyProofMetadata {
-                                proof_signing_alg_values_supported: vec![Algorithm::ES256]
+                                proof_signing_alg_values_supported: vec!["ES256".to_string()]
                             }
                         )]
                         .into_iter()
@@ -406,7 +405,7 @@ mod tests {
                         proof_types_supported: vec![(
                             ProofType::Jwt,
                             KeyProofMetadata {
-                                proof_signing_alg_values_supported: vec![Algorithm::ES256]
+                                proof_signing_alg_values_supported: vec!["ES256".to_string()]
                             }
                         )]
                         .into_iter()

--- a/oid4vci/src/credential_issuer/credential_issuer_metadata.rs
+++ b/oid4vci/src/credential_issuer/credential_issuer_metadata.rs
@@ -57,7 +57,6 @@ mod tests {
         credential_issuer::credential_configurations_supported::ClaimDescription,
         proof::{KeyProofMetadata, ProofType},
     };
-    use jsonwebtoken::Algorithm;
     use oid4vc_core::claim_path_pointer::{ClaimPathElement, ClaimPathPointer};
     use serde_json::{from_str, json};
 
@@ -117,7 +116,7 @@ mod tests {
                         proof_types_supported: vec![(
                             ProofType::Jwt,
                             KeyProofMetadata {
-                                proof_signing_alg_values_supported: vec![Algorithm::ES256]
+                                proof_signing_alg_values_supported: vec!["ES256".to_string()]
                             }
                         )]
                         .into_iter()

--- a/oid4vci/src/proof.rs
+++ b/oid4vci/src/proof.rs
@@ -24,7 +24,7 @@ impl Proof {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct KeyProofMetadata {
-    pub proof_signing_alg_values_supported: Vec<Algorithm>,
+    pub proof_signing_alg_values_supported: Vec<String>,
     // TODO: add `key_attestations_required`
 }
 

--- a/oid4vci/src/wallet/mod.rs
+++ b/oid4vci/src/wallet/mod.rs
@@ -263,7 +263,9 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
         self.proof_signing_alg_values_supported
             .iter()
             .find(|supported_algorithm| {
-                credential_issuer_proof_signing_alg_values_supported.contains(supported_algorithm)
+                // Since `Algorithm` does not implement `Display`, we need to use `Debug` in order to convert it to a `String`.
+                let supported_algorithm_str = format!("{supported_algorithm:?}");
+                credential_issuer_proof_signing_alg_values_supported.contains(&supported_algorithm_str)
             })
             .cloned()
             .ok_or(anyhow::anyhow!("No matching supported signing algorithms found."))
@@ -433,7 +435,7 @@ pub mod tests {
                     ProofType::Jwt,
                     KeyProofMetadata {
                         // This proof signing algorithm will not match any of the Wallet's supported signing algorithms.
-                        proof_signing_alg_values_supported: vec![Algorithm::RS256],
+                        proof_signing_alg_values_supported: vec!["RS256".to_string()],
                     },
                 )]),
                 ..Default::default()
@@ -461,7 +463,7 @@ pub mod tests {
                     ProofType::Jwt,
                     KeyProofMetadata {
                         // This proof signing algorithm will match the Wallet's supported signing algorithms.
-                        proof_signing_alg_values_supported: vec![Algorithm::EdDSA],
+                        proof_signing_alg_values_supported: vec!["EdDSA".to_string()],
                     },
                 )]),
                 ..Default::default()


### PR DESCRIPTION
# Description of change
Previously, the `proof_signing_alg_values_supported` field in our data structures was defined as a `Vec<Algorithm>`. This created a strict requirement that every string in an issuer's metadata must correspond to a known variant of the `jsonwebtoken::Algorithm` enum.

This caused the entire deserialization process to fail if an issuer's metadata included a new or unsupported algorithm that the `Algorithm` enum did not recognize. This brittleness made it difficult to interoperate with issuers that support a wider range of algorithms.

To resolve this, the type of `proof_signing_alg_values_supported` has been changed from `Vec<Algorithm>` to `Vec<String>`.

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes