### PR TITLE
fix: update OAuth Authorization Server Metadata endpoint construction

### DIFF
--- a/oid4vci/src/wallet/mod.rs
+++ b/oid4vci/src/wallet/mod.rs
@@ -94,13 +94,19 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
     ) -> Result<AuthorizationServerMetadata> {
         let mut oauth_authorization_server_endpoint = credential_issuer_url.clone();
 
-        // TODO(NGDIL): remove this NGDIL specific code. This is a temporary fix to get the authorization server metadata.
+        // According to RFC8414, the path to the OAuth Authorization Server Metadata is formed by
+        // appending `/.well-known/oauth-authorization-server` to the issuer's origin. If the issuer
+        // URL contains a path, then that path must be appended to the well-known path.
+        // See: https://www.rfc-editor.org/rfc/rfc8414.html#section-3
+        oauth_authorization_server_endpoint.set_path(&format!(
+            "/.well-known/oauth-authorization-server{}",
+            credential_issuer_url.path()
+        ));
+
         oauth_authorization_server_endpoint
             .path_segments_mut()
             .map_err(|_| anyhow::anyhow!("unable to parse credential issuer url"))?
-            .pop_if_empty()
-            .push(".well-known")
-            .push("oauth-authorization-server");
+            .pop_if_empty();
 
         self.client
             .get(oauth_authorization_server_endpoint)
@@ -484,7 +490,7 @@ pub mod tests {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))
-            .and(path("/some/path/.well-known/oauth-authorization-server"))
+            .and(path("/.well-known/oauth-authorization-server/some/path"))
             .respond_with(ResponseTemplate::new(200).set_body_json(AuthorizationServerMetadata::default()))
             .mount(&mock_server)
             .await;

--- a/oid4vci/src/wallet/mod.rs
+++ b/oid4vci/src/wallet/mod.rs
@@ -94,10 +94,10 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
     ) -> Result<AuthorizationServerMetadata> {
         let mut oauth_authorization_server_endpoint = credential_issuer_url.clone();
 
-        // According to RFC8414, the path to the OAuth Authorization Server Metadata is formed by
+        // According to RFC 8414, the path to the OAuth Authorization Server Metadata is formed by
         // appending `/.well-known/oauth-authorization-server` to the issuer's origin. If the issuer
         // URL contains a path, then that path must be appended to the well-known path.
-        // See: https://www.rfc-editor.org/rfc/rfc8414.html#section-3
+        // See RFC 8414 Section 3: https://www.rfc-editor.org/rfc/rfc8414.html#section-3
         oauth_authorization_server_endpoint.set_path(&format!(
             "/.well-known/oauth-authorization-server{}",
             credential_issuer_url.path()

--- a/oid4vci/src/wallet/mod.rs
+++ b/oid4vci/src/wallet/mod.rs
@@ -108,13 +108,36 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
             .map_err(|_| anyhow::anyhow!("unable to parse credential issuer url"))?
             .pop_if_empty();
 
+        let response = self.client.get(oauth_authorization_server_endpoint).send().await;
+
+        if let Ok(response) = response {
+            // If the request to the `oauth-authorization-server` endpoint is successful, return the metadata.
+            if response.status().is_success() {
+                return response
+                    .json::<AuthorizationServerMetadata>()
+                    .await
+                    .map_err(|e| anyhow!("Failed to parse authorization server metadata: {}", e));
+            }
+        }
+
+        // If the request to the `oauth-authorization-server` endpoint fails, fallback to the OpenID Provider Configuration endpoint.
+        // See RFC 8414 Section 5: https://www.rfc-editor.org/rfc/rfc8414.html#section-5
+        let mut openid_configuration_endpoint = credential_issuer_url.clone();
+
+        openid_configuration_endpoint
+            .path_segments_mut()
+            .map_err(|_| anyhow::anyhow!("unable to parse credential issuer url"))?
+            .pop_if_empty()
+            .push(".well-known")
+            .push("openid-configuration");
+
         self.client
-            .get(oauth_authorization_server_endpoint)
+            .get(openid_configuration_endpoint)
             .send()
             .await?
             .json::<AuthorizationServerMetadata>()
             .await
-            .map_err(|_| anyhow::anyhow!("Failed to get authorization server metadata"))
+            .map_err(|e| anyhow!("Failed to get metadata from both primary and fallback endpoints: {}", e))
     }
 
     pub async fn get_credential_issuer_metadata(
@@ -491,6 +514,38 @@ pub mod tests {
 
         Mock::given(method("GET"))
             .and(path("/.well-known/oauth-authorization-server/some/path"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(AuthorizationServerMetadata::default()))
+            .mount(&mock_server)
+            .await;
+
+        // Assert that the Wallet can get the Authorization Server Metadata from the Credential Issuer URL with or without a trailing slash.
+        let credential_issuer_url = format!("{}/some/path/", mock_server.uri()).parse().unwrap();
+        assert!(wallet
+            .get_authorization_server_metadata(credential_issuer_url)
+            .await
+            .is_ok());
+
+        let credential_issuer_url = format!("{}/some/path", mock_server.uri()).parse().unwrap();
+        assert!(wallet
+            .get_authorization_server_metadata(credential_issuer_url)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn wallet_successfully_retrieves_authorization_server_metadata_from_openid_configuration() {
+        // Create a new Wallet.
+        let wallet: Wallet = Wallet::new(
+            Arc::new(TestSubject::default()),
+            vec!["did:test"],
+            vec![Algorithm::EdDSA],
+        )
+        .unwrap();
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/some/path/.well-known/openid-configuration"))
             .respond_with(ResponseTemplate::new(200).set_body_json(AuthorizationServerMetadata::default()))
             .mount(&mock_server)
             .await;

--- a/oid4vci/src/wallet/mod.rs
+++ b/oid4vci/src/wallet/mod.rs
@@ -58,7 +58,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
         supported_subject_syntax_types: Vec<impl TryInto<SubjectSyntaxType>>,
         proof_signing_alg_values_supported: Vec<Algorithm>,
     ) -> anyhow::Result<Self> {
-        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(5);
+        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(2);
         let client = ClientBuilder::new(reqwest::Client::new())
             .with(RetryTransientMiddleware::new_with_policy(retry_policy))
             .build();


### PR DESCRIPTION
# Description of change
This change corrects the logic in the `get_authorization_server_metadata` function to properly construct the metadata URL as specified in RFC 8414.

Previously, the well-known path was appended to the issuer's path. The logic is now fixed to place the issuer's path components **after** the `/.well-known/oauth-authorization-server` segment.

Example:

Before: `https://example.com/issuer` -> `https://example.com/issuer/.well-known/oauth-authorization-server`
After: `https://example.com/issuer` -> `https://example.com/.well-known/oauth-authorization-server/issuer`

Furthermore, in line with [RFC 8414 Section 5](https://www.rfc-editor.org/rfc/rfc8414.html#section-5), a fallback to the `/.well-known/openid-configuration` endpoint is added that will be used when the `/.well-known/oauth-authorization-server` does not exist.

Finally, the amount of retries is reduced from 5 to 2 in order to reduce some significant unnecessary user-facing delay (this decreases max duration from 31 secs to 3 secs).

## Links to any relevant issues
https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#section-11.2.3-2.2
https://www.rfc-editor.org/rfc/rfc8414.html#section-3
https://www.rfc-editor.org/rfc/rfc8414.html#section-5

## How the change has been tested
Existing test has been updated

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes