### PR TITLE
fix: improve deserialization robustness and simplify generics

### DIFF
--- a/oid4vc-core/src/test_utils.rs
+++ b/oid4vc-core/src/test_utils.rs
@@ -61,6 +61,7 @@ impl Subject for TestSubject {
     }
 }
 
+#[derive(Default)]
 pub struct MockVerifier;
 
 impl MockVerifier {

--- a/oid4vc-manager/src/managers/credential_issuer.rs
+++ b/oid4vc-manager/src/managers/credential_issuer.rs
@@ -2,7 +2,6 @@ use crate::storage::Storage;
 use anyhow::Result;
 use oid4vc_core::Subject;
 use oid4vci::{
-    credential_format_profiles::CredentialFormatCollection,
     credential_issuer::{
         authorization_server_metadata::AuthorizationServerMetadata,
         credential_issuer_metadata::CredentialIssuerMetadata, CredentialIssuer,
@@ -13,14 +12,14 @@ use reqwest::Url;
 use std::{net::TcpListener, sync::Arc};
 
 #[derive(Clone)]
-pub struct CredentialIssuerManager<S: Storage<CFC>, CFC: CredentialFormatCollection> {
-    pub credential_issuer: CredentialIssuer<CFC>,
+pub struct CredentialIssuerManager<S: Storage> {
+    pub credential_issuer: CredentialIssuer,
     pub subject: Arc<dyn Subject>,
     pub storage: S,
     pub listener: Arc<TcpListener>,
 }
 
-impl<S: Storage<CFC>, CFC: CredentialFormatCollection> CredentialIssuerManager<S, CFC> {
+impl<S: Storage> CredentialIssuerManager<S> {
     pub fn new(listener: Option<TcpListener>, storage: S, subject: Arc<dyn Subject>) -> Result<Self> {
         // `TcpListener::bind("127.0.0.1:0")` will bind to a random port.
         let listener = listener.unwrap_or_else(|| TcpListener::bind("127.0.0.1:0").unwrap());

--- a/oid4vc-manager/src/servers/credential_issuer.rs
+++ b/oid4vc-manager/src/servers/credential_issuer.rs
@@ -16,7 +16,6 @@ use oid4vci::{
     notification_request::NotificationRequest,
     token_request::TokenRequest,
 };
-use serde::de::DeserializeOwned;
 use tokio::task::JoinHandle;
 use tower_http::cors::AllowOrigin;
 
@@ -34,7 +33,7 @@ where
     pub detached: bool,
 }
 
-impl<S: Storage + Clone + Clone + DeserializeOwned + 'static> Server<S> {
+impl<S: Storage + Clone + 'static> Server<S> {
     pub fn setup(
         credential_issuer_manager: CredentialIssuerManager<S>,
         extension: Option<Router<CredentialIssuerManager<S>>>,

--- a/oid4vc-manager/src/servers/credential_issuer.rs
+++ b/oid4vc-manager/src/servers/credential_issuer.rs
@@ -12,7 +12,6 @@ use axum::{
 use axum_auth::AuthBearer;
 use oid4vc_core::Validator;
 use oid4vci::{
-    credential_format_profiles::CredentialFormatCollection,
     credential_request::{CredentialIdentifierOrCredentialConfigurationId, CredentialRequest},
     notification_request::NotificationRequest,
     token_request::TokenRequest,
@@ -25,21 +24,20 @@ use tower_http::cors::AllowOrigin;
 
 pub const TEST_PRE_AUTHORIZED_SUBJECT_DID: &str = "did:example:pre-authorized-subject";
 
-pub struct Server<S, CFC>
+pub struct Server<S>
 where
-    S: Storage<CFC>,
-    CFC: CredentialFormatCollection,
+    S: Storage,
 {
-    pub credential_issuer_manager: CredentialIssuerManager<S, CFC>,
+    pub credential_issuer_manager: CredentialIssuerManager<S>,
     pub server: Option<JoinHandle<()>>,
-    pub extension: Option<Router<CredentialIssuerManager<S, CFC>>>,
+    pub extension: Option<Router<CredentialIssuerManager<S>>>,
     pub detached: bool,
 }
 
-impl<S: Storage<CFC> + Clone, CFC: CredentialFormatCollection + Clone + DeserializeOwned + 'static> Server<S, CFC> {
+impl<S: Storage + Clone + Clone + DeserializeOwned + 'static> Server<S> {
     pub fn setup(
-        credential_issuer_manager: CredentialIssuerManager<S, CFC>,
-        extension: Option<Router<CredentialIssuerManager<S, CFC>>>,
+        credential_issuer_manager: CredentialIssuerManager<S>,
+        extension: Option<Router<CredentialIssuerManager<S>>>,
     ) -> Result<Self> {
         Ok(Self {
             credential_issuer_manager,
@@ -105,8 +103,8 @@ impl<S: Storage<CFC> + Clone, CFC: CredentialFormatCollection + Clone + Deserial
     }
 }
 
-async fn oauth_authorization_server<S: Storage<CFC>, CFC: CredentialFormatCollection>(
-    State(credential_issuer_manager): State<CredentialIssuerManager<S, CFC>>,
+async fn oauth_authorization_server<S: Storage>(
+    State(credential_issuer_manager): State<CredentialIssuerManager<S>>,
 ) -> impl IntoResponse {
     (
         StatusCode::OK,
@@ -118,8 +116,8 @@ async fn oauth_authorization_server<S: Storage<CFC>, CFC: CredentialFormatCollec
     )
 }
 
-async fn openid_credential_issuer<S: Storage<CFC>, CFC: CredentialFormatCollection>(
-    State(credential_issuer_manager): State<CredentialIssuerManager<S, CFC>>,
+async fn openid_credential_issuer<S: Storage>(
+    State(credential_issuer_manager): State<CredentialIssuerManager<S>>,
 ) -> impl IntoResponse {
     (
         StatusCode::OK,
@@ -127,8 +125,8 @@ async fn openid_credential_issuer<S: Storage<CFC>, CFC: CredentialFormatCollecti
     )
 }
 
-async fn credential_offer<S: Storage<CFC>, CFC: CredentialFormatCollection>(
-    State(credential_issuer_manager): State<CredentialIssuerManager<S, CFC>>,
+async fn credential_offer<S: Storage>(
+    State(credential_issuer_manager): State<CredentialIssuerManager<S>>,
 ) -> impl IntoResponse {
     (
         StatusCode::OK,
@@ -136,8 +134,8 @@ async fn credential_offer<S: Storage<CFC>, CFC: CredentialFormatCollection>(
     )
 }
 
-async fn par<S: Storage<CFC>, CFC: CredentialFormatCollection>(
-    State(credential_issuer_manager): State<CredentialIssuerManager<S, CFC>>,
+async fn par<S: Storage>(
+    State(credential_issuer_manager): State<CredentialIssuerManager<S>>,
     Form(_pushed_authorization_request): Form<serde_json::Value>,
 ) -> impl IntoResponse {
     (
@@ -151,8 +149,8 @@ async fn par<S: Storage<CFC>, CFC: CredentialFormatCollection>(
     )
 }
 
-async fn authorize<S: Storage<CFC>, CFC: CredentialFormatCollection>(
-    State(credential_issuer_manager): State<CredentialIssuerManager<S, CFC>>,
+async fn authorize<S: Storage>(
+    State(credential_issuer_manager): State<CredentialIssuerManager<S>>,
     Form(_authorization_request): Form<serde_json::Value>,
 ) -> impl IntoResponse {
     (
@@ -162,8 +160,8 @@ async fn authorize<S: Storage<CFC>, CFC: CredentialFormatCollection>(
     )
 }
 
-async fn token<S: Storage<CFC>, CFC: CredentialFormatCollection>(
-    State(credential_issuer_manager): State<CredentialIssuerManager<S, CFC>>,
+async fn token<S: Storage>(
+    State(credential_issuer_manager): State<CredentialIssuerManager<S>>,
     Form(token_request): Form<TokenRequest>,
 ) -> impl IntoResponse {
     match credential_issuer_manager.storage.get_token_response(token_request) {
@@ -183,8 +181,8 @@ async fn token<S: Storage<CFC>, CFC: CredentialFormatCollection>(
     }
 }
 
-async fn credential<S: Storage<CFC>, CFC: CredentialFormatCollection>(
-    State(credential_issuer_manager): State<CredentialIssuerManager<S, CFC>>,
+async fn credential<S: Storage>(
+    State(credential_issuer_manager): State<CredentialIssuerManager<S>>,
     AuthBearer(access_token): AuthBearer,
     Json(credential_request): Json<CredentialRequest>,
 ) -> impl IntoResponse {

--- a/oid4vc-manager/src/storage.rs
+++ b/oid4vc-manager/src/storage.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use oid4vc_core::authentication::subject::SigningSubject;
 use oid4vci::{
     authorization_response::AuthorizationResponse,
-    credential_format_profiles::CredentialFormatCollection,
     credential_issuer::credential_configurations_supported::CredentialConfigurationsSupportedObject,
     credential_offer::{AuthorizationCode, PreAuthorizedCode},
     credential_response::CredentialResponse,
@@ -14,11 +13,8 @@ use oid4vci::{
 use reqwest::Url;
 
 // Represents the Credential Issuer's server logic.
-pub trait Storage<CFC>: Send + Sync + 'static
-where
-    CFC: CredentialFormatCollection,
-{
-    fn get_credential_configurations_supported(&self) -> HashMap<String, CredentialConfigurationsSupportedObject<CFC>>;
+pub trait Storage: Send + Sync {
+    fn get_credential_configurations_supported(&self) -> HashMap<String, CredentialConfigurationsSupportedObject>;
     fn get_pushed_authorization_response(&self) -> Option<PushedAuthorizationResponse>;
     fn get_authorization_response(&self) -> Option<AuthorizationResponse>;
     fn get_authorization_code(&self) -> Option<AuthorizationCode>;

--- a/oid4vc-manager/tests/common/memory_storage.rs
+++ b/oid4vc-manager/tests/common/memory_storage.rs
@@ -7,7 +7,6 @@ use oid4vc_core::{authentication::subject::SigningSubject, generate_authorizatio
 use oid4vc_manager::storage::Storage;
 use oid4vci::{
     authorization_response::AuthorizationResponse,
-    credential_format_profiles::CredentialFormatCollection,
     credential_issuer::credential_configurations_supported::CredentialConfigurationsSupportedObject,
     credential_offer::{AuthorizationCode, PreAuthorizedCode},
     credential_response::{CredentialResponse, CredentialResponseObject, CredentialResponseType},
@@ -17,7 +16,7 @@ use oid4vci::{
     VerifiableCredentialJwt,
 };
 use reqwest::Url;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use uuid::Uuid;
 
@@ -35,8 +34,8 @@ lazy_static! {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MemoryStorage;
 
-impl<CFC: CredentialFormatCollection + DeserializeOwned> Storage<CFC> for MemoryStorage {
-    fn get_credential_configurations_supported(&self) -> HashMap<String, CredentialConfigurationsSupportedObject<CFC>> {
+impl Storage for MemoryStorage {
+    fn get_credential_configurations_supported(&self) -> HashMap<String, CredentialConfigurationsSupportedObject> {
         vec![
             (
                 "UniversityDegree_JWT".to_string(),

--- a/oid4vc-manager/tests/oid4vci/authorization_code.rs
+++ b/oid4vc-manager/tests/oid4vci/authorization_code.rs
@@ -10,7 +10,6 @@ use oid4vci::authorization_request::CodeChallengeMethod;
 use oid4vci::pkce;
 use oid4vci::{
     authorization_details::{AuthorizationDetailsObject, CredentialConfigurationOrFormat, OpenidCredential},
-    credential_format_profiles::{CredentialFormats, WithParameters},
     credential_response::{CredentialResponse, CredentialResponseType},
     token_request::TokenRequest,
     Wallet,
@@ -21,8 +20,8 @@ use uuid::Uuid;
 #[tokio::test]
 async fn test_authorization_code_flow() {
     // Setup the credential issuer.
-    let mut credential_issuer: Server<_, _> = Server::setup(
-        CredentialIssuerManager::<_, CredentialFormats<WithParameters>>::new(
+    let mut credential_issuer: Server<_> = Server::setup(
+        CredentialIssuerManager::<_>::new(
             None,
             MemoryStorage,
             Arc::new(KeySubject::from_keypair(

--- a/oid4vc-manager/tests/oid4vci/pre_authorized_code.rs
+++ b/oid4vc-manager/tests/oid4vci/pre_authorized_code.rs
@@ -6,7 +6,6 @@ use oid4vc_manager::{
     servers::credential_issuer::Server,
 };
 use oid4vci::{
-    credential_format_profiles::{CredentialFormats, WithParameters},
     credential_offer::{CredentialOffer, CredentialOfferParameters, Grants},
     credential_response::{CredentialResponse, CredentialResponseType},
     notification_request::NotificationEvent,
@@ -23,7 +22,7 @@ use std::sync::Arc;
 #[tokio::test]
 async fn test_pre_authorized_code_flow(#[case] batch: bool, #[case] by_reference: bool) {
     // Setup the credential issuer.
-    let mut credential_issuer = Server::<_, CredentialFormats<WithParameters>>::setup(
+    let mut credential_issuer = Server::<_>::setup(
         CredentialIssuerManager::new(
             None,
             MemoryStorage,

--- a/oid4vci/src/authorization_details.rs
+++ b/oid4vci/src/authorization_details.rs
@@ -1,7 +1,5 @@
 use crate::{
-    credential_format_profiles::{
-        CredentialConfiguration, CredentialFormatCollection, CredentialFormats, WithParameters,
-    },
+    credential_format_profiles::{CredentialConfiguration, CredentialFormats, WithParameters},
     credential_issuer::credential_configurations_supported::ClaimDescription,
 };
 use oid4vc_core::claim_path_pointer::ClaimPathPointer;
@@ -22,14 +20,11 @@ pub enum OpenidCredential {
 /// described here: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#name-using-authorization-details
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
-pub struct AuthorizationDetailsObject<CFC = CredentialFormats<WithParameters>>
-where
-    CFC: CredentialFormatCollection,
-{
+pub struct AuthorizationDetailsObject {
     pub r#type: OpenidCredential,
     pub locations: Option<Vec<Url>>,
     #[serde(flatten)]
-    pub credential_configuration_or_format: CredentialConfigurationOrFormat<CFC>,
+    pub credential_configuration_or_format: CredentialConfigurationOrFormat,
     pub claims: Option<Vec<AuthorizationDetailsClaim>>,
 }
 
@@ -51,16 +46,13 @@ impl From<ClaimDescription> for AuthorizationDetailsClaim {
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 #[serde(untagged)]
-pub enum CredentialConfigurationOrFormat<CFC = CredentialFormats<WithParameters>>
-where
-    CFC: CredentialFormatCollection,
-{
+pub enum CredentialConfigurationOrFormat {
     CredentialConfigurationId {
         credential_configuration_id: String,
         #[serde(flatten)]
         parameters: Option<CredentialConfiguration>,
     },
-    CredentialFormat(CFC),
+    CredentialFormat(CredentialFormats<WithParameters>),
 }
 
 #[cfg(test)]
@@ -87,7 +79,7 @@ mod tests {
         });
 
         assert_eq!(
-            AuthorizationDetailsObject::<CredentialFormats<WithParameters>> {
+            AuthorizationDetailsObject {
                 r#type: OpenidCredential::Type,
                 locations: None,
                 credential_configuration_or_format: CredentialConfigurationOrFormat::CredentialFormat(

--- a/oid4vci/src/authorization_request.rs
+++ b/oid4vci/src/authorization_request.rs
@@ -1,7 +1,4 @@
-use crate::{
-    authorization_details::AuthorizationDetailsObject,
-    credential_format_profiles::{CredentialFormatCollection, CredentialFormats, WithParameters},
-};
+use crate::authorization_details::AuthorizationDetailsObject;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;
@@ -9,16 +6,13 @@ use url::Url;
 /// The Authorization Request is used to request authorization as described here: openid.net/specs/openid-4-verifiable-presentations-1_0-28.html#name-authorization-request
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct AuthorizationRequest<CFC = CredentialFormats<WithParameters>>
-where
-    CFC: CredentialFormatCollection,
-{
+pub struct AuthorizationRequest {
     pub response_type: String,
     pub client_id: String,
     pub redirect_uri: Option<Url>,
     pub scope: Option<String>,
     pub state: Option<String>,
-    pub authorization_details: Vec<AuthorizationDetailsObject<CFC>>,
+    pub authorization_details: Vec<AuthorizationDetailsObject>,
     pub issuer_state: Option<String>,
     // PKCE parameters
     pub code_challenge: Option<String>,

--- a/oid4vci/src/credential_format_profiles/mod.rs
+++ b/oid4vci/src/credential_format_profiles/mod.rs
@@ -23,7 +23,6 @@ macro_rules! credential_format {
             pub struct $name;
             impl $crate::credential_format_profiles::Format for $name {
                 type Parameters = [< $name Parameters >];
-                type Credential = serde_json::Value;
             }
 
             #[serde_with::skip_serializing_none]
@@ -52,7 +51,6 @@ macro_rules! credential_format {
 
 pub trait Format: std::fmt::Debug + Sync + Send + Clone {
     type Parameters: std::fmt::Debug + Serialize + Clone + Send + Sync;
-    type Credential: std::fmt::Debug + Serialize + Clone + Send + Sync;
 }
 
 mod sealed {
@@ -81,21 +79,6 @@ where
     #[serde(flatten)]
     pub parameters: F::Parameters,
 }
-
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
-pub struct WithCredential;
-impl FormatExtension for WithCredential {
-    type Container<F: Format> = Credential<F>;
-}
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
-pub struct Credential<F>
-where
-    F: Format,
-{
-    pub credential: F::Credential,
-}
-
-pub trait CredentialFormatCollection: Serialize + Send + Sync + Clone + std::fmt::Debug {}
 
 #[derive(Debug, Serialize, Clone, Eq, PartialEq, Deserialize, Default)]
 #[serde(tag = "format")]
@@ -129,8 +112,6 @@ pub enum CredentialConfiguration {
     MsoMdoc(Option<serde_json::Value>),
 }
 
-impl<C> CredentialFormatCollection for CredentialFormats<C> where C: FormatExtension {}
-
 impl<C> CredentialFormats<C>
 where
     C: FormatExtension,
@@ -144,20 +125,6 @@ where
             CredentialFormats::DcSdJwt(_) => CredentialFormats::DcSdJwt(()),
             CredentialFormats::VcSdJwt(_) => CredentialFormats::VcSdJwt(()),
             CredentialFormats::Unknown => CredentialFormats::Unknown,
-        }
-    }
-}
-
-impl CredentialFormats<WithCredential> {
-    pub fn credential(&self) -> anyhow::Result<&serde_json::Value> {
-        match self {
-            CredentialFormats::JwtVcJson(credential) => Ok(&credential.credential),
-            CredentialFormats::JwtVcJsonLd(credential) => Ok(&credential.credential),
-            CredentialFormats::LdpVc(credential) => Ok(&credential.credential),
-            CredentialFormats::MsoMdoc(credential) => Ok(&credential.credential),
-            CredentialFormats::DcSdJwt(credential) => Ok(&credential.credential),
-            CredentialFormats::VcSdJwt(credential) => Ok(&credential.credential),
-            CredentialFormats::Unknown => Err(anyhow::anyhow!("Unknown credential format")),
         }
     }
 }

--- a/oid4vci/src/credential_issuer/credential_configurations_supported.rs
+++ b/oid4vci/src/credential_issuer/credential_configurations_supported.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    credential_format_profiles::{CredentialFormatCollection, CredentialFormats, WithParameters},
+    credential_format_profiles::{CredentialFormats, WithParameters},
     proof::{KeyProofMetadata, ProofType},
 };
 use oid4vc_core::claim_path_pointer::ClaimPathPointer;
@@ -12,13 +12,10 @@ use url::Url;
 /// Credentials Supported object as described here: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#section-11.2.3-2.11.1
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
-pub struct CredentialConfigurationsSupportedObject<CFC = CredentialFormats<WithParameters>>
-where
-    CFC: CredentialFormatCollection,
-{
+pub struct CredentialConfigurationsSupportedObject {
     /// This field is flattened into a `format` field and optionally extra format-specific fields.
     #[serde(flatten)]
-    pub credential_format: CFC,
+    pub credential_format: CredentialFormats<WithParameters>,
     // Use `Scope` from oid4vc-core/src/scope.rs.
     pub scope: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]

--- a/oid4vci/src/credential_issuer/credential_issuer_metadata.rs
+++ b/oid4vci/src/credential_issuer/credential_issuer_metadata.rs
@@ -61,7 +61,7 @@ where
         .filter_map(|(key, value)| {
             serde_json::from_value::<CredentialConfigurationsSupportedObject>(value)
                 .ok()
-                .and_then(|credential_configuration| Some((key, credential_configuration)))
+                .map(|credential_configuration| (key, credential_configuration))
         })
         .collect();
 

--- a/oid4vci/src/credential_issuer/credential_issuer_metadata.rs
+++ b/oid4vci/src/credential_issuer/credential_issuer_metadata.rs
@@ -1,8 +1,7 @@
 use super::credential_configurations_supported::CredentialConfigurationsSupportedObject;
-use crate::credential_format_profiles::{CredentialFormatCollection, CredentialFormats, WithParameters};
 use derivative::Derivative;
 use reqwest::Url;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 
@@ -23,10 +22,7 @@ pub struct BatchCredentialIssuance {
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Derivative)]
 #[derivative(Default)]
-pub struct CredentialIssuerMetadata<CFC = CredentialFormats<WithParameters>>
-where
-    CFC: CredentialFormatCollection,
-{
+pub struct CredentialIssuerMetadata {
     // TODO: Temporary solution
     #[derivative(Default(value = "Url::parse(\"https://example.com\").unwrap()"))]
     pub credential_issuer: Url,
@@ -43,7 +39,33 @@ where
     pub batch_credential_issuance: Option<BatchCredentialIssuance>,
     pub signed_metadata: Option<String>,
     pub display: Option<Vec<serde_json::Value>>,
-    pub credential_configurations_supported: HashMap<String, CredentialConfigurationsSupportedObject<CFC>>,
+    #[serde(default, deserialize_with = "deserialize_credential_configurations_supported")]
+    pub credential_configurations_supported: HashMap<String, CredentialConfigurationsSupportedObject>,
+}
+
+// A custom deserialization function to filter out invalid map entries.
+fn deserialize_credential_configurations_supported<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, CredentialConfigurationsSupportedObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // First, deserialize into a map of raw JSON values. This will not fail
+    // unless the JSON structure itself is not a map.
+    let map: HashMap<String, serde_json::Value> = HashMap::deserialize(deserializer)?;
+
+    // Iterate over the raw map and try to deserialize each value.
+    // Collect only the ones that succeed.
+    let valid_map = map
+        .into_iter()
+        .filter_map(|(key, value)| {
+            serde_json::from_value::<CredentialConfigurationsSupportedObject>(value)
+                .ok()
+                .and_then(|credential_configuration| Some((key, credential_configuration)))
+        })
+        .collect();
+
+    Ok(valid_map)
 }
 
 #[cfg(test)]
@@ -191,5 +213,42 @@ mod tests {
             ))
             .unwrap()
         );
+    }
+
+    #[test]
+    fn test_deserialize_with_invalid_entry() {
+        // The second entry is invalid because it lacks the `credential_definition` field.
+        let json_data = serde_json::json!(
+            {
+                "credential_issuer": "https://credential-issuer.example.org",
+                "credential_endpoint": "https://credential-issuer.example.org",
+                "credential_configurations_supported": {
+                    "ValidCredential": {
+                        "format": "jwt_vc_json",
+                        "credential_definition":{
+                            "type": [
+                                "VerifiableCredential"
+                            ]
+                        }
+                    },
+                    "InvalidCredential": {
+                        "format": "jwt_vc_json",
+                    }
+                }
+            }
+        );
+
+        // Deserialize the JSON data into the CredentialIssuerMetadata struct.
+        let credential_issuer_metadata: CredentialIssuerMetadata = serde_json::from_value(json_data).unwrap();
+
+        // Check that only the valid entry is present in the resulting map.
+        assert!(credential_issuer_metadata
+            .credential_configurations_supported
+            .contains_key("ValidCredential"));
+
+        // Check that the invalid entry has been filtered out.
+        assert!(!credential_issuer_metadata
+            .credential_configurations_supported
+            .contains_key("InvalidCredential"));
     }
 }

--- a/oid4vci/src/credential_issuer/mod.rs
+++ b/oid4vci/src/credential_issuer/mod.rs
@@ -5,20 +5,17 @@ pub mod credential_issuer_metadata;
 use self::{
     authorization_server_metadata::AuthorizationServerMetadata, credential_issuer_metadata::CredentialIssuerMetadata,
 };
-use crate::{credential_format_profiles::CredentialFormatCollection, proof::ProofOfPossession, Proof};
+use crate::{proof::ProofOfPossession, Proof};
 use oid4vc_core::{authentication::subject::SigningSubject, Validator};
 
 #[derive(Clone)]
-pub struct CredentialIssuer<CFC>
-where
-    CFC: CredentialFormatCollection,
-{
+pub struct CredentialIssuer {
     pub subject: SigningSubject,
-    pub metadata: CredentialIssuerMetadata<CFC>,
+    pub metadata: CredentialIssuerMetadata,
     pub authorization_server_metadata: AuthorizationServerMetadata,
 }
 
-impl<CFC: CredentialFormatCollection> CredentialIssuer<CFC> {
+impl CredentialIssuer {
     pub async fn validate_proof(&self, proof: Proof, validator: Validator) -> anyhow::Result<ProofOfPossession> {
         match proof {
             Proof::Jwt { jwt, .. } => validator.decode(jwt).await,

--- a/oid4vci/src/errors.rs
+++ b/oid4vci/src/errors.rs
@@ -261,11 +261,7 @@ mod tests {
         );
 
         assert!(
-            response
-                .headers()
-                .get("Content-Type")
-                .and_then(|v| v.to_str().ok())
-                .map_or(false, |content_type| content_type == "application/json"),
+            response.headers().get("Content-Type").and_then(|v| v.to_str().ok()) == Some("application/json"),
             "Content-Type header should be application/json"
         );
     }

--- a/oid4vci/src/wallet/mod.rs
+++ b/oid4vci/src/wallet/mod.rs
@@ -309,7 +309,7 @@ impl Wallet {
             // If no match is found, use the first supported syntax type as a fallback.
             .or_else(|| self.supported_subject_syntax_types.first())
             .cloned()
-            .ok_or(anyhow::anyhow!("No supported subject syntax types found. 2"))
+            .ok_or(anyhow::anyhow!("No supported subject syntax types found."))
     }
 
     pub async fn get_nonce(&self, nonce_endpoint: Url) -> Result<String> {

--- a/oid4vci/src/wallet/mod.rs
+++ b/oid4vci/src/wallet/mod.rs
@@ -1,7 +1,6 @@
 use crate::authorization_details::AuthorizationDetailsObject;
 use crate::authorization_request::{AuthorizationRequest, CodeChallengeMethod};
 use crate::authorization_response::AuthorizationResponse;
-use crate::credential_format_profiles::{CredentialFormatCollection, CredentialFormats, WithParameters};
 use crate::credential_issuer::credential_configurations_supported::CredentialConfigurationsSupportedObject;
 use crate::credential_issuer::{
     authorization_server_metadata::AuthorizationServerMetadata, credential_issuer_metadata::CredentialIssuerMetadata,
@@ -23,19 +22,14 @@ use reqwest::Url;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::RetryTransientMiddleware;
-use serde::de::DeserializeOwned;
 use std::str::FromStr;
 
 #[derive(Debug)]
-pub struct Wallet<CFC = CredentialFormats<WithParameters>>
-where
-    CFC: CredentialFormatCollection,
-{
+pub struct Wallet {
     pub subject: SigningSubject,
     pub supported_subject_syntax_types: Vec<SubjectSyntaxType>,
     pub client: ClientWithMiddleware,
     pub proof_signing_alg_values_supported: Vec<Algorithm>,
-    phantom: std::marker::PhantomData<CFC>,
 }
 
 // TODO: Move everything related to pushed authorization response to a separate module?
@@ -52,7 +46,7 @@ pub struct AuthorizationRequestByReference {
     pub request_uri: String,
 }
 
-impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
+impl Wallet {
     pub fn new(
         subject: SigningSubject,
         supported_subject_syntax_types: Vec<impl TryInto<SubjectSyntaxType>>,
@@ -74,7 +68,6 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
                 .collect::<Result<_>>()?,
             client,
             proof_signing_alg_values_supported,
-            phantom: std::marker::PhantomData,
         })
     }
 
@@ -140,10 +133,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
             .map_err(|e| anyhow!("Failed to get metadata from both primary and fallback endpoints: {}", e))
     }
 
-    pub async fn get_credential_issuer_metadata(
-        &self,
-        credential_issuer_url: Url,
-    ) -> Result<CredentialIssuerMetadata<CFC>> {
+    pub async fn get_credential_issuer_metadata(&self, credential_issuer_url: Url) -> Result<CredentialIssuerMetadata> {
         let mut openid_credential_issuer_endpoint = credential_issuer_url.clone();
 
         // TODO(NGDIL): remove this NGDIL specific code. This is a temporary fix to get the credential issuer metadata.
@@ -158,7 +148,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
             .get(openid_credential_issuer_endpoint)
             .send()
             .await?
-            .json::<CredentialIssuerMetadata<CFC>>()
+            .json()
             .await
             .map_err(|_| anyhow::anyhow!("Failed to get credential issuer metadata"))
     }
@@ -172,7 +162,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
         client_id: &str,
         redirect_uri: Url,
         state: String,
-        authorization_details: Vec<AuthorizationDetailsObject<CFC>>,
+        authorization_details: Vec<AuthorizationDetailsObject>,
         issuer_state: String,
         code_challenge: Option<String>,
         code_challenge_method: Option<CodeChallengeMethod>,
@@ -209,7 +199,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
     pub async fn get_authorization_code(
         &self,
         authorization_endpoint: Url,
-        _authorization_details: Vec<AuthorizationDetailsObject<CFC>>,
+        _authorization_details: Vec<AuthorizationDetailsObject>,
         _code_challenge: Option<String>,
         _code_challenge_method: Option<String>,
         pushed_authorization_response: Option<PushedAuthorizationResponse>,
@@ -316,8 +306,10 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
             .find(|supported_syntax_type| {
                 credential_issuer_cryptographic_binding_methods_supported.contains(supported_syntax_type)
             })
+            // If no match is found, use the first supported syntax type as a fallback.
+            .or_else(|| self.supported_subject_syntax_types.first())
             .cloned()
-            .ok_or(anyhow::anyhow!("No supported subject syntax types found."))
+            .ok_or(anyhow::anyhow!("No supported subject syntax types found. 2"))
     }
 
     pub async fn get_nonce(&self, nonce_endpoint: Url) -> Result<String> {
@@ -334,7 +326,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
 
     pub async fn get_credential(
         &self,
-        credential_issuer_metadata: CredentialIssuerMetadata<CFC>,
+        credential_issuer_metadata: CredentialIssuerMetadata,
         token_response: &TokenResponse,
         nonce: Option<String>,
         credential_configuration_id: String,
@@ -580,9 +572,7 @@ pub mod tests {
 
         Mock::given(method("GET"))
             .and(path("/some/path/.well-known/openid-credential-issuer"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(CredentialIssuerMetadata::<CredentialFormats>::default()),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(CredentialIssuerMetadata::default()))
             .mount(&mock_server)
             .await;
 


### PR DESCRIPTION
# Description of change
This pull request introduces two major improvements: it makes `CredentialIssuerMetadata` deserialization more robust and simplifies the crate's overall design by removing a complex generic abstraction.

1. Robust Deserialization
Previously, if a credential issuer's metadata contained even a single invalid entry within the `credential_configurations_supported` map, the entire deserialization process would fail. This made the system brittle and unable to handle minor inconsistencies in an issuer's published metadata.

This has been fixed by implementing a custom deserializer `deserialize_credential_configurations_supported` which:

* Attempts to deserialize each entry in the map individually.
* Filters out and **ignores any malformed entries** instead of failing.
* Ensures that all valid credential configurations are loaded successfully.

A new unit test, `test_deserialize_with_invalid_entry` has been added to verify this new, more resilient behavior.

2. Generic Simplification
The generic `CredentialFormatCollection` trait has been removed from `Wallet`, `CredentialIssuer`, `AuthorizationDetailsObject` and other related structs throughout the `oid4vci` and `oid4vc-manager` crates.

This refactoring significantly simplifies the codebase, and makes the types easier to work with by removing a layer of generic complexity that was no longer necessary. All related structs now use concrete types for credential formats.

## Links to any relevant issues
n/a

## How the change has been tested
Added unit test `test_deserialize_with_invalid_entry`

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes