### PR TITLE
fix: validate all Credentials and nonces in Authorization Response

### DIFF
--- a/oid4vci/src/errors.rs
+++ b/oid4vci/src/errors.rs
@@ -129,7 +129,7 @@ impl Display for TokenErrorResponse {
     }
 }
 
-/// Credential Error Response as defined in OpenID4VCI - draft 13 - Section 7.3.1: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID1.html#name-credential-error-response
+/// Credential Error Response as defined in OpenID4VCI - draft 15 - Section 8.3.1 https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID2.html#name-credential-error-response
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CredentialErrorResponse {
@@ -139,6 +139,8 @@ pub enum CredentialErrorResponse {
     InvalidEncryptionParameters,
     InvalidProof,
     InvalidToken,
+    InvalidNonce,
+    CredentialRequestDenied,
 }
 
 impl ErrorStatusCode for CredentialErrorResponse {
@@ -150,6 +152,8 @@ impl ErrorStatusCode for CredentialErrorResponse {
             Self::InvalidProof => StatusCode::BAD_REQUEST,
             Self::InvalidEncryptionParameters => StatusCode::BAD_REQUEST,
             Self::InvalidToken => StatusCode::UNAUTHORIZED,
+            Self::InvalidNonce => StatusCode::BAD_REQUEST,
+            Self::CredentialRequestDenied => StatusCode::FORBIDDEN,
         }
     }
 }
@@ -164,6 +168,8 @@ impl Display for CredentialErrorResponse {
             Self::InvalidEncryptionParameters => write!(f, "Invalid Encryption Parameters"),
             Self::InvalidProof => write!(f, "Invalid Proof"),
             Self::InvalidToken => write!(f, "Invalid Token"),
+            Self::InvalidNonce => write!(f, "Invalid Nonce"),
+            Self::CredentialRequestDenied => write!(f, "Credential Request Denied"),
         }
     }
 }

--- a/oid4vci/src/errors.rs
+++ b/oid4vci/src/errors.rs
@@ -153,7 +153,7 @@ impl ErrorStatusCode for CredentialErrorResponse {
             Self::InvalidEncryptionParameters => StatusCode::BAD_REQUEST,
             Self::InvalidToken => StatusCode::UNAUTHORIZED,
             Self::InvalidNonce => StatusCode::BAD_REQUEST,
-            Self::CredentialRequestDenied => StatusCode::FORBIDDEN,
+            Self::CredentialRequestDenied => StatusCode::BAD_REQUEST,
         }
     }
 }

--- a/oid4vp/src/oid4vp.rs
+++ b/oid4vp/src/oid4vp.rs
@@ -3,7 +3,6 @@ use crate::authorization_request::{
 };
 use crate::dcql::dcql_query::CredentialQueryId;
 use crate::token::verifiable_presentation_jwt::VerifiablePresentationJwt;
-// use crate::token::verifiable_presentation_jwt_builder::VerifiablePresentationJwtBuilder;
 use crate::token::vp_token::{PresentationFormat, VpToken};
 use anyhow::anyhow;
 use futures::future::join_all;

--- a/oid4vp/src/oid4vp.rs
+++ b/oid4vp/src/oid4vp.rs
@@ -3,6 +3,7 @@ use crate::authorization_request::{
 };
 use crate::dcql::dcql_query::CredentialQueryId;
 use crate::token::verifiable_presentation_jwt::VerifiablePresentationJwt;
+// use crate::token::verifiable_presentation_jwt_builder::VerifiablePresentationJwtBuilder;
 use crate::token::vp_token::{PresentationFormat, VpToken};
 use anyhow::anyhow;
 use futures::future::join_all;
@@ -46,7 +47,22 @@ impl ResponseHandle for ResponseHandler {
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct DecodedVpToken {
     #[serde(flatten)]
-    pub presentations: HashMap<CredentialQueryId, Vec<VerifiableCredentialJwt>>,
+    pub presentations: HashMap<CredentialQueryId, Vec<VerifiablePresentationJwt>>,
+}
+
+impl DecodedVpToken {
+    pub fn nonce(&self) -> Option<String> {
+        // Making the assumption that all VPs in the token have the same nonce
+        for presentations in self.presentations.values() {
+            for vp in presentations {
+                if let Some(nonce) = vp.nonce() {
+                    return Some(nonce.clone());
+                    // TODO: (Edge case)What if different VPs have different nonces?
+                }
+            }
+        }
+        None
+    }
 }
 
 /// This is the [`Extension`] implementation for the [`OID4VP`] extension.
@@ -172,23 +188,29 @@ impl Extension for OID4VP {
         authorization_response: &AuthorizationResponse<Self>,
     ) -> anyhow::Result<DecodedVpToken> {
         let vp_token = &authorization_response.extension.vp_token;
-        let mut decoded_presentations: HashMap<CredentialQueryId, Vec<VerifiableCredentialJwt>> = HashMap::new();
+        let mut decoded_presentations: HashMap<CredentialQueryId, Vec<VerifiablePresentationJwt>> = HashMap::new();
         for (credential_query_id, presentation_formats) in vp_token.presentations() {
-            let mut all_decoded_credentials = Vec::new();
+            let mut all_decoded_vps = Vec::new();
             for presentation_format in presentation_formats {
                 match presentation_format {
                     PresentationFormat::JwtVcJson(jwt_string) => {
-                        let decoded_presentation: VerifiablePresentationJwt =
-                            validator.decode(jwt_string.clone()).await?;
-                        let credential_futures: Vec<_> = decoded_presentation
-                            .verifiable_presentation()
-                            .verifiable_credential
-                            .iter()
-                            .map(|vc_jwt| validator.decode(vc_jwt.as_str().to_owned()))
+                        // Decode the vp envelope
+                        let decoded_vp: VerifiablePresentationJwt = validator.decode(jwt_string.clone()).await?;
+
+                        // Verify the credentials inside the vp
+                        let inner_vcs = decoded_vp.verifiable_presentation().verifiable_credential.iter();
+
+                        let credential_futures: Vec<_> = inner_vcs
+                            .map(|vc_jwt| validator.decode::<VerifiableCredentialJwt>(vc_jwt.as_str().to_owned()))
                             .collect();
-                        let decoded_credentials: Result<Vec<_>, _> =
-                            join_all(credential_futures).await.into_iter().collect();
-                        all_decoded_credentials.append(&mut decoded_credentials?);
+
+                        // If any of the inner VCs fail, throw an error.
+                        let _verified_inner_vcs: Vec<VerifiableCredentialJwt> = join_all(credential_futures)
+                            .await
+                            .into_iter()
+                            .collect::<Result<_, _>>()?;
+
+                        all_decoded_vps.push(decoded_vp);
                     }
                     // TODO: handle additional formats DcSdJwt, LdpVc and MsoMdoc
                     _ => {
@@ -196,7 +218,7 @@ impl Extension for OID4VP {
                     }
                 }
             }
-            decoded_presentations.insert(credential_query_id.clone(), all_decoded_credentials);
+            decoded_presentations.insert(credential_query_id.clone(), all_decoded_vps);
         }
 
         Ok(DecodedVpToken {

--- a/oid4vp/src/oid4vp.rs
+++ b/oid4vp/src/oid4vp.rs
@@ -54,19 +54,19 @@ impl DecodedVpToken {
     // and ensure that it is linked to the values of the client_id and the nonce parameter it had used for the respective Authorization Request.
     // If any Verifiable Presentation in the response does not contain the correct nonce value, the response MUST be rejected.
     pub fn validate_nonce(&self, expected_nonce: &str) -> Result<(), String> {
-        for (credential_id, presentations) in &self.presentations {
+        for (credential_query_id, presentations) in &self.presentations {
             for (index, vp) in presentations.iter().enumerate() {
                 match vp.nonce() {
                     Some(nonce) if nonce != expected_nonce => {
                         return Err(format!(
                             "Nonce mismatch in VP for credential query ID {:?} at index {}",
-                            credential_id, index
+                            credential_query_id, index
                         ))
                     }
                     None => {
                         return Err(format!(
                             "Missing nonce in VP for credential query ID {:?} at index {}",
-                            credential_id, index
+                            credential_query_id, index
                         ))
                     }
                     Some(_) => {}

--- a/oid4vp/src/oid4vp.rs
+++ b/oid4vp/src/oid4vp.rs
@@ -50,17 +50,30 @@ pub struct DecodedVpToken {
 }
 
 impl DecodedVpToken {
-    pub fn nonce(&self) -> Option<String> {
-        // Making the assumption that all VPs in the token have the same nonce
-        for presentations in self.presentations.values() {
-            for vp in presentations {
-                if let Some(nonce) = vp.nonce() {
-                    return Some(nonce.clone());
-                    // TODO: (Edge case)What if different VPs have different nonces?
+    // The Verifier MUST validate every individual Verifiable Presentation in an Authorization Response
+    // and ensure that it is linked to the values of the client_id and the nonce parameter it had used for the respective Authorization Request.
+    // If any Verifiable Presentation in the response does not contain the correct nonce value, the response MUST be rejected.
+    pub fn validate_nonce(&self, expected_nonce: &str) -> Result<(), String> {
+        for (credential_id, presentations) in &self.presentations {
+            for (index, vp) in presentations.iter().enumerate() {
+                match vp.nonce() {
+                    Some(nonce) if nonce != expected_nonce => {
+                        return Err(format!(
+                            "Nonce mismatch in VP for credential query ID {:?} at index {}",
+                            credential_id, index
+                        ))
+                    }
+                    None => {
+                        return Err(format!(
+                            "Missing nonce in VP for credential query ID {:?} at index {}",
+                            credential_id, index
+                        ))
+                    }
+                    Some(_) => {}
                 }
             }
         }
-        None
+        Ok(())
     }
 }
 

--- a/oid4vp/src/token/verifiable_presentation_jwt.rs
+++ b/oid4vp/src/token/verifiable_presentation_jwt.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Getters, PartialEq)]
+#[derive(Serialize, Clone, Deserialize, Debug, Getters, PartialEq)]
 pub struct VerifiablePresentationJwt {
     #[serde(flatten)]
     #[getset(get = "pub")]
@@ -14,6 +14,7 @@ pub struct VerifiablePresentationJwt {
     #[serde(rename = "vp")]
     #[getset(get = "pub")]
     pub(super) verifiable_presentation: Presentation<Jwt>,
+    #[getset(get = "pub")]
     pub(super) nonce: Option<String>,
 }
 


### PR DESCRIPTION
# Description of change
Previously, the `decode_authorization_response` function would extract only the inner VerifiableCredentialJwt level of the vp_token. This meant that the "outer" VerifiablePresentationJwt (VP) shell of the token was discarded after decoding.
Because the nonce claim resides on the Presentation layer and not the Credential layer, it was impossible to perform nonce validation in our authorization_request Aggregate.

This PR changes the format of the DecodedVpToken struct to store the full VerifiablePresentationJwt wrapper. The decoding logic has been updated to:

1. Verify the outer VP signature. 
2. Verify the inner VC signatures to ensure its integrity.
3. Preserve the outer VP object in the returned struct.

A helper method `.validate_nonce()` was also added to DecodedVpToken to allow the Aggregate in our ssi-agent to easily extract and validate the nonces from the verified presentations.


## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes