### PR TITLE
feat: enhance `VpToken` validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,22 @@ repository = "https://github.com/impierce/openid4vc"
 
 [workspace.dependencies]
 chrono = "0.4"
+# TODO: replace did-key
+did-key = "0.2"
 getset = "0.1"
 http = "1.3.1"
+identity_did = { git = "https://github.com/iotaledger/identity", tag = "v1.9.1-beta.1" }
+identity_document = { git = "https://github.com/iotaledger/identity", tag = "v1.9.1-beta.1" }
+identity_ecdsa_verifier = { git = "https://github.com/iotaledger/identity", tag = "v1.9.1-beta.1" }
+identity_eddsa_verifier = { git = "https://github.com/iotaledger/identity", tag = "v1.9.1-beta.1" }
 identity_credential = { git = "https://github.com/iotaledger/identity", tag = "v1.9.1-beta.1", default-features = false, features = [
     "validator",
     "credential",
     "presentation",
     "sd-jwt-vc",
 ] }
+identity_jose = { git = "https://github.com/iotaledger/identity", tag = "v1.9.1-beta.1" }
+identity_verification = { git = "https://github.com/iotaledger/identity", tag = "v1.9.1-beta.1" }
 is_empty = "0.2"
 jsonwebtoken = "9.3"
 monostate = "0.1"
@@ -43,12 +51,27 @@ serde_with = "3.0"
 tokio = { version = "1.46", features = ["rt", "macros", "rt-multi-thread"] }
 thiserror = "1.0"
 url = { version = "2", features = ["serde"] }
-validator = { version = "0.19", features = ["derive"] }
 
-# TODO: Fix these dependencies once publishing to crates.io is automated.
 [dependencies]
 oid4vc-core = { path = "oid4vc-core" }
 oid4vci = { path = "oid4vci" }
 oid4vp = { path = "oid4vp" }
 siopv2 = { path = "siopv2" }
 oid4vc-manager = { path = "oid4vc-manager" }
+
+# TODO: remove these patches once these changes are merged: https://github.com/iotaledger/identity/compare/v1.9.1-beta.1...impierce:identity.rs:fix/issues?expand=1
+[patch.'https://github.com/iotaledger/identity']
+identity_core = { git = "https://github.com/impierce/identity.rs", rev = "0422797b" }
+identity_credential = { git = "https://github.com/impierce/identity.rs", rev = "0422797b" }
+identity_did = { git = "https://github.com/impierce/identity.rs", rev = "0422797b" }
+identity_document = { git = "https://github.com/impierce/identity.rs", rev = "0422797b" }
+identity_iota = { git = "https://github.com/impierce/identity.rs", rev = "0422797b" }
+identity_jose = { git = "https://github.com/impierce/identity.rs", rev = "0422797b" }
+identity_storage = { git = "https://github.com/impierce/identity.rs", rev = "0422797b" }
+identity_verification = { git = "https://github.com/impierce/identity.rs", rev = "0422797b" }
+identity_ecdsa_verifier = { git = "https://github.com/impierce/identity.rs", rev = "0422797b" }
+identity_eddsa_verifier = { git = "https://github.com/impierce/identity.rs", rev = "0422797b" }
+
+[patch.crates-io]
+# We need this patch because it makes the `Hasher` trait `Send` and `Sync`. See: https://github.com/iotaledger/sd-jwt-payload/compare/main...impierce:sd-jwt-payload:fix/hasher-send-sync
+sd-jwt = { git = "https://github.com/impierce/sd-jwt-payload", rev = "f28789a", package = "sd-jwt-payload" }

--- a/oid4vc-core/Cargo.toml
+++ b/oid4vc-core/Cargo.toml
@@ -10,9 +10,16 @@ async-trait = "0.1.68"
 base64-url = "2.0.0"
 derivative = "2.2.0"
 derive_more = "0.99.16"
+did-key.workspace = true
 did_url = "0.1.0"
 ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 getset = "0.1.2"
+identity_did.workspace = true
+identity_document.workspace = true
+identity_ecdsa_verifier.workspace = true
+identity_eddsa_verifier.workspace = true
+identity_jose.workspace = true
+identity_verification.workspace = true
 is_empty = "0.2.0"
 jsonwebtoken.workspace = true
 lazy_static = "1.4.0"

--- a/oid4vc-core/src/claim_path_pointer.rs
+++ b/oid4vc-core/src/claim_path_pointer.rs
@@ -29,7 +29,7 @@ pub enum ClaimPathElement {
 }
 
 impl ClaimPathPointer {
-    /// As described in OID4VP - draft 28 Section 7.1 for JSON-based credentials:
+    /// As described in OID4VP - Section 7.1 for JSON-based credentials:
     /// https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-semantics-for-json-based-cr
     /// TODO: Add semantics for ISO Mdoc credential format.
     pub fn get_values_from_json(&self, json_data: &Value) -> Vec<Value> {

--- a/oid4vc-core/src/jwt.rs
+++ b/oid4vc-core/src/jwt.rs
@@ -77,7 +77,7 @@ where
     Ok(message)
 }
 
-fn base64_url_encode<T>(value: &T) -> Result<String>
+pub fn base64_url_encode<T>(value: &T) -> Result<String>
 where
     T: ?Sized + Serialize,
 {

--- a/oid4vc-core/src/lib.rs
+++ b/oid4vc-core/src/lib.rs
@@ -8,7 +8,10 @@ pub mod openid4vc_extension;
 pub mod rfc7519_claims;
 pub mod scope;
 pub mod subject_syntax_type;
+pub mod types;
 pub mod utils;
+pub mod verification_material_resolver;
+pub mod verifier;
 
 pub use authentication::{sign::Sign, subject::Subject, validator::Validator, verify::Verify};
 use rand::{distributions::Alphanumeric, Rng};

--- a/oid4vc-core/src/types/mod.rs
+++ b/oid4vc-core/src/types/mod.rs
@@ -1,0 +1,1 @@
+pub mod string_or_object;

--- a/oid4vc-core/src/types/string_or_object.rs
+++ b/oid4vc-core/src/types/string_or_object.rs
@@ -1,0 +1,70 @@
+use crate::JsonObject;
+use serde::{Deserialize, Serialize};
+
+/// Simple enum that can be used to represent either a string or a JSON object.
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum StringOrObject {
+    String(String),
+    Object(JsonObject),
+}
+
+impl StringOrObject {
+    pub fn as_str(&self) -> Option<&str> {
+        if let StringOrObject::String(string) = self {
+            Some(string)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_object(&self) -> Option<&JsonObject> {
+        if let StringOrObject::Object(object) = self {
+            Some(object)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<String> for StringOrObject {
+    fn from(string: String) -> Self {
+        Self::String(string)
+    }
+}
+
+impl From<&str> for StringOrObject {
+    fn from(string: &str) -> Self {
+        Self::String(string.to_string())
+    }
+}
+
+impl From<JsonObject> for StringOrObject {
+    fn from(object: JsonObject) -> Self {
+        Self::Object(object)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serde_roundtrip_string() {
+        let original = StringOrObject::String("hello".to_string());
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: StringOrObject = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn test_serde_roundtrip_object() {
+        let original = StringOrObject::Object(JsonObject::from_iter(vec![(
+            "key".to_string(),
+            serde_json::json!("value"),
+        )]));
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: StringOrObject = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, deserialized);
+    }
+}

--- a/oid4vc-core/src/verification_material_resolver.rs
+++ b/oid4vc-core/src/verification_material_resolver.rs
@@ -2,8 +2,8 @@ use async_trait::async_trait;
 use identity_document::document::CoreDocument;
 use identity_jose::jwk::Jwk;
 
-/// A trait for resolving verification materials (DID Documents and public keys).Many components in the OID4VC ecosystem rely on the ability to resolve key material.
-/// This trait abstracts away the details of how DIDs and public keys are resolved. More resolver method should be added in the future.
+/// A trait for resolving verification materials (DID Documents and public keys). Many components in the OID4VC ecosystem rely on the ability to resolve key material.
+/// This trait abstracts away the details of how DIDs and public keys are resolved. More resolver methods should be added in the future.
 #[async_trait]
 pub trait VerificationMaterialResolver: Send + Sync {
     /// Resolves the full DID Document

--- a/oid4vc-core/src/verification_material_resolver.rs
+++ b/oid4vc-core/src/verification_material_resolver.rs
@@ -1,0 +1,55 @@
+use async_trait::async_trait;
+use identity_document::document::CoreDocument;
+use identity_jose::jwk::Jwk;
+
+/// A trait for resolving verification materials (DID Documents and public keys).Many components in the OID4VC ecosystem rely on the ability to resolve key material.
+/// This trait abstracts away the details of how DIDs and public keys are resolved. More resolver method should be added in the future.
+#[async_trait]
+pub trait VerificationMaterialResolver: Send + Sync {
+    /// Resolves the full DID Document
+    async fn resolve_did_document(
+        &self,
+        did: &identity_did::CoreDID,
+    ) -> Result<CoreDocument, Box<dyn std::error::Error>>;
+
+    /// Resolves a specific public key (JWK) by its Key ID
+    async fn resolve_public_key(&self, kid: &str) -> Result<Jwk, Box<dyn std::error::Error>>;
+}
+
+#[cfg(feature = "test-utils")]
+pub mod test_utils {
+    use super::*;
+    use did_key::DIDCore as _;
+    use identity_did::{DIDUrl, DID as _};
+
+    /// A simple implementation of the `VerificationMaterialResolver` trait for testing purposes. It uses the `did:key` method to resolve DIDs and public keys.
+    pub struct TestVerificationMaterialResolver;
+
+    #[async_trait]
+    impl VerificationMaterialResolver for TestVerificationMaterialResolver {
+        async fn resolve_did_document(
+            &self,
+            did: &identity_did::CoreDID,
+        ) -> Result<CoreDocument, Box<dyn std::error::Error>> {
+            let res = Ok(serde_json::from_value(serde_json::json!(did_key::resolve(did.as_str())
+                .unwrap()
+                .get_did_document(did_key::CONFIG_JOSE_PUBLIC)))
+            .unwrap());
+
+            res
+        }
+
+        async fn resolve_public_key(&self, kid: &str) -> Result<identity_jose::jwk::Jwk, Box<dyn std::error::Error>> {
+            let document = self
+                .resolve_did_document(DIDUrl::parse(kid).unwrap().did())
+                .await
+                .unwrap();
+
+            let key = document.resolve_method(kid, None).unwrap();
+
+            let res = Ok(key.data().public_key_jwk().cloned().unwrap());
+
+            res
+        }
+    }
+}

--- a/oid4vc-core/src/verifier.rs
+++ b/oid4vc-core/src/verifier.rs
@@ -1,0 +1,23 @@
+use identity_ecdsa_verifier::EcDSAJwsVerifier;
+use identity_eddsa_verifier::EdDSAJwsVerifier;
+use identity_verification::{
+    jwk::Jwk,
+    jws::{JwsAlgorithm, JwsVerifier, SignatureVerificationError, SignatureVerificationErrorKind, VerificationInput},
+};
+
+/// A simple JWS verifier that supports EdDSA and ES256/ES256K algorithms. This can be used to verify signatures on JWTs and other JWS objects.
+#[derive(Clone)]
+pub struct SignatureVerifier;
+
+impl JwsVerifier for SignatureVerifier {
+    fn verify(&self, input: VerificationInput, public_key: &Jwk) -> Result<(), SignatureVerificationError> {
+        use JwsAlgorithm::*;
+
+        match input.alg {
+            EdDSA => EdDSAJwsVerifier::default().verify(input, public_key),
+            ES256 | ES256K => EcDSAJwsVerifier::default().verify(input, public_key),
+            // TODO: Add support for more algorithms.
+            _ => Err(SignatureVerificationErrorKind::UnsupportedAlg.into()),
+        }
+    }
+}

--- a/oid4vc-manager/Cargo.toml
+++ b/oid4vc-manager/Cargo.toml
@@ -17,7 +17,7 @@ axum = "0.6"
 axum-auth = "0.4"
 chrono.workspace = true
 derivative = "2.2"
-did-key = "0.2"
+did-key.workspace = true
 did_url = "0.1"
 futures = "0.3"
 getset.workspace = true
@@ -38,6 +38,10 @@ url.workspace = true
 oid4vc-core = { path = "../oid4vc-core", features = ["test-utils"] }
 
 ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
+identity_did.workspace = true
+identity_document.workspace = true
+identity_jose.workspace = true
+identity_verification.workspace = true
 lazy_static = "1.4"
 rand = "0.8"
 rstest = "0.18"

--- a/oid4vc-manager/src/managers/relying_party.rs
+++ b/oid4vc-manager/src/managers/relying_party.rs
@@ -43,10 +43,14 @@ impl RelyingPartyManager {
             .await
     }
 
+    #[deprecated(
+        note = "This function is only used for validating `SIOPv2` Authorization Responses. For validating `OID4VP` Authorization Responses use the `VpTokenValidator` instead."
+    )]
     pub async fn validate_response<E: Extension>(
         &self,
         authorization_response: &AuthorizationResponse<E>,
     ) -> Result<<E::ResponseHandle as ResponseHandle>::ResponseItem> {
+        #[allow(deprecated)]
         self.relying_party.validate_response(authorization_response).await
     }
 

--- a/oid4vc-manager/src/methods/key_method.rs
+++ b/oid4vc-manager/src/methods/key_method.rs
@@ -162,9 +162,9 @@ mod tests {
         // Let the relying party validate the authorization_response.
         let relying_party_manager =
             RelyingPartyManager::new(Arc::new(KeySubject::new()), "did:key", vec![Algorithm::EdDSA]).unwrap();
-        assert!(relying_party_manager
-            .validate_response(&authorization_response)
-            .await
-            .is_ok());
+
+        #[allow(deprecated)]
+        let res = relying_party_manager.validate_response(&authorization_response).await;
+        assert!(res.is_ok());
     }
 }

--- a/oid4vc-manager/tests/oid4vp/implicit.rs
+++ b/oid4vc-manager/tests/oid4vp/implicit.rs
@@ -4,24 +4,27 @@ use identity_credential::{credential::Jwt, presentation::Presentation};
 use jsonwebtoken::{Algorithm, Header};
 use lazy_static::lazy_static;
 use oid4vc_core::authentication::subject::Subject;
+use oid4vc_core::verification_material_resolver::test_utils::TestVerificationMaterialResolver;
+use oid4vc_core::verifier::SignatureVerifier;
 use oid4vc_core::{
     authorization_request::{AuthorizationRequest, Object},
     authorization_response::AuthorizationResponse,
     client_metadata::ClientMetadataResource,
     jwt,
 };
-use oid4vc_manager::{methods::key_method::KeySubject, ProviderManager, RelyingPartyManager};
+use oid4vc_manager::{methods::key_method::KeySubject, ProviderManager};
 use oid4vci::VerifiableCredentialJwt;
 use oid4vp::authorization_request::AlgValues;
 use oid4vp::authorization_request::{JwtVcJsonParameters, VpFormatsSupported};
 use oid4vp::token::verifiable_presentation_jwt::VerifiablePresentationJwt;
+use oid4vp::token::vp_token::Presentations;
+use oid4vp::token::vp_token_validator::VpTokenValidator;
 use oid4vp::{
     authorization_request::{ClientId, ClientMetadataParameters},
     oid4vp::OID4VP,
 };
 use oid4vp::{
     dcql::dcql_query::{CredentialQueryId, DcqlQuery},
-    token::vp_token::PresentationFormat,
     token::vp_token_builder::VpTokenBuilder,
 };
 
@@ -56,12 +59,12 @@ async fn test_implicit_flow() {
     const TEST_DID_METHOD: &str = "did:key";
 
     // Create a new issuer.
-    let issuer = KeySubject::from_keypair(
+    let issuer = Arc::new(KeySubject::from_keypair(
         generate::<Ed25519KeyPair>(Some(
             "this-is-a-very-UNSAFE-issuer-secret-key".as_bytes().try_into().unwrap(),
         )),
         None,
-    );
+    ));
     let issuer_did = issuer.identifier(TEST_DID_METHOD, Algorithm::EdDSA).await.unwrap();
 
     // Create a new subject.
@@ -77,11 +80,11 @@ async fn test_implicit_flow() {
         .identifier(TEST_DID_METHOD, Algorithm::EdDSA)
         .await
         .unwrap();
-    let relying_party_manager =
-        RelyingPartyManager::new(relying_party, TEST_DID_METHOD, vec![Algorithm::EdDSA]).unwrap();
 
     let relying_party_did_with_prefix =
         ClientId::from_str(&format!("decentralized_identifier:{}", relying_party_did)).unwrap();
+
+    let nonce = "nonce";
 
     // Create authorization request with response_type `id_token vp_token`
     let authorization_request = AuthorizationRequest::<Object<OID4VP>>::builder()
@@ -106,7 +109,7 @@ async fn test_implicit_flow() {
             )]),
         })
         .response_mode("query".to_string())
-        .nonce("nonce".to_string())
+        .nonce(nonce)
         .build()
         .unwrap();
 
@@ -129,7 +132,6 @@ async fn test_implicit_flow() {
                 "VerifiableCredential",
                 "PersonalInformation"
             ],
-            "issuanceDate": "2022-01-01T00:00:00Z",
             "issuer": issuer_did,
             "credentialSubject": {
             "id": subject_did,
@@ -144,7 +146,7 @@ async fn test_implicit_flow() {
 
     // Encode the verifiable credential as a JWT.
     let jwt = jwt::encode(
-        subject.clone(),
+        issuer.clone(),
         Header {
             alg: Algorithm::EdDSA,
             ..Default::default()
@@ -186,9 +188,9 @@ async fn test_implicit_flow() {
     .unwrap();
 
     let vp_token = VpTokenBuilder::builder_dcql_query(DCQL_QUERY.clone())
-        .add_presentation(
+        .add_presentations(
             CredentialQueryId::try_new("my_credential".to_string()).unwrap(),
-            PresentationFormat::JwtVcJson(verifiable_presentation_jwt),
+            Presentations::try_new(vec![verifiable_presentation_jwt.into()]).unwrap(),
         )
         .build()
         .unwrap();
@@ -198,9 +200,17 @@ async fn test_implicit_flow() {
         .await
         .unwrap();
 
-    // Validate the authorization_response.
-    assert!(relying_party_manager
-        .validate_response(&authorization_response)
-        .await
-        .is_ok());
+    let signature_verifier = SignatureVerifier;
+
+    assert!(
+        VpTokenValidator::new(signature_verifier, TestVerificationMaterialResolver)
+            .validate_vp_token(
+                &DCQL_QUERY,
+                &authorization_response.extension.vp_token,
+                &relying_party_did_with_prefix.to_string(),
+                Some(nonce),
+            )
+            .await
+            .is_ok()
+    );
 }

--- a/oid4vc-manager/tests/oid4vp/implicit.rs
+++ b/oid4vc-manager/tests/oid4vp/implicit.rs
@@ -189,7 +189,7 @@ async fn test_implicit_flow() {
 
     let vp_token = VpTokenBuilder::builder_dcql_query(DCQL_QUERY.clone())
         .add_presentations(
-            CredentialQueryId::try_new("my_credential".to_string()).unwrap(),
+            CredentialQueryId::try_new("my_credential").unwrap(),
             Presentations::try_new(vec![verifiable_presentation_jwt.into()]).unwrap(),
         )
         .build()

--- a/oid4vc-manager/tests/oid4vp/implicit.rs
+++ b/oid4vc-manager/tests/oid4vp/implicit.rs
@@ -200,10 +200,8 @@ async fn test_implicit_flow() {
         .await
         .unwrap();
 
-    let signature_verifier = SignatureVerifier;
-
     assert!(
-        VpTokenValidator::new(signature_verifier, TestVerificationMaterialResolver)
+        VpTokenValidator::new(&SignatureVerifier, &TestVerificationMaterialResolver)
             .validate_vp_token(
                 &DCQL_QUERY,
                 &authorization_response.extension.vp_token,

--- a/oid4vc-manager/tests/siopv2/implicit.rs
+++ b/oid4vc-manager/tests/siopv2/implicit.rs
@@ -252,6 +252,7 @@ async fn test_implicit_flow(#[case] did_method: &str) {
     // The `RelyingParty` then validates the authorization_response by decoding the header of the id_token, by fetching the public
     // key corresponding to the key identifier and finally decoding the id_token using the public key and by
     // validating the signature.
+    #[allow(deprecated)]
     let id_token = relying_party_manager
         .validate_response(&authorization_response)
         .await

--- a/oid4vp/Cargo.toml
+++ b/oid4vp/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-# Fix these dependencies once the crates arre automatically published to crates.io.
 oid4vc-core = { path = "../oid4vc-core" }
 oid4vci = { path = "../oid4vci" }
 
@@ -18,6 +17,10 @@ chrono.workspace = true
 futures = "0.3"
 getset.workspace = true
 identity_credential.workspace = true
+identity_did.workspace = true
+identity_document.workspace = true
+identity_jose.workspace = true
+identity_verification.workspace = true
 is_empty.workspace = true
 jsonwebtoken.workspace = true
 lazy_static = "1.4.0"
@@ -29,6 +32,9 @@ reqwest-retry.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 url.workspace = true
-validator.workspace = true
+
+[dev-dependencies]
+oid4vc-core = { path = "../oid4vc-core", features = ["test-utils"] }

--- a/oid4vp/src/dcql/claims.rs
+++ b/oid4vp/src/dcql/claims.rs
@@ -1,12 +1,28 @@
 use super::dcql_query::ClaimQuery;
-use validator::ValidationError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DcqlClaimsError {
+    #[error("Claims cannot be empty when claim_sets is used")]
+    EmptyClaims,
+    #[error("Claim ID is required when claim_sets is present, missing at index {0}")]
+    MissingClaimId(usize),
+    #[error("Claim ID '{0}' at index {1} contains invalid characters. Only alphanumeric, underscore, and hyphen characters are allowed")]
+    InvalidClaimIdFormat(String, usize),
+    #[error("Claim ID cannot be empty at index {0}")]
+    EmptyClaimId(usize),
+    #[error("Duplicate claim ID '{0}' found at index {1}")]
+    DuplicateClaimId(String, usize),
+    #[error("Claim ID '{0}' not found in claims at claim_set[{1}][{2}]")]
+    InvalidClaimIdReference(String, usize, usize),
+}
 
 #[derive(Debug)]
 pub struct ClaimsContext<'a> {
     pub claim_sets: &'a Option<Vec<Vec<String>>>,
 }
 
-pub fn validate_claims(claims: &[ClaimQuery], ctx: &ClaimsContext) -> Result<(), ValidationError> {
+pub fn validate_claims(claims: &[ClaimQuery], ctx: &ClaimsContext) -> Result<(), DcqlClaimsError> {
     if let Some(claim_sets) = ctx.claim_sets {
         validate_claims_with_sets(claims, claim_sets)?;
     } else {
@@ -16,19 +32,15 @@ pub fn validate_claims(claims: &[ClaimQuery], ctx: &ClaimsContext) -> Result<(),
     Ok(())
 }
 
-pub fn validate_claims_with_sets(claims: &[ClaimQuery], claim_sets: &[Vec<String>]) -> Result<(), ValidationError> {
+pub fn validate_claims_with_sets(claims: &[ClaimQuery], claim_sets: &[Vec<String>]) -> Result<(), DcqlClaimsError> {
     if claims.is_empty() {
-        return Err(
-            ValidationError::new("empty_claims").with_message("Claims cannot be empty when claim_sets is used".into())
-        );
+        return Err(DcqlClaimsError::EmptyClaims);
     }
 
     // When claim_sets is present, each claim is required to have an ID.
     for (i, claim) in claims.iter().enumerate() {
         if claim.id.is_none() {
-            return Err(ValidationError::new("missing_claim_id").with_message(
-                format!("Claim ID is required when claim_sets is present, missing at index {i}").into(),
-            ));
+            return Err(DcqlClaimsError::MissingClaimId(i));
         }
     }
 
@@ -43,7 +55,7 @@ pub fn validate_claims_with_sets(claims: &[ClaimQuery], claim_sets: &[Vec<String
     Ok(())
 }
 
-pub fn validate_claims_without_sets(claims: &[ClaimQuery]) -> Result<(), ValidationError> {
+pub fn validate_claims_without_sets(claims: &[ClaimQuery]) -> Result<(), DcqlClaimsError> {
     // When claim_sets is not present, IDs are optional but must be unique if they exist
     validate_claim_ids(claims)?;
 
@@ -51,22 +63,19 @@ pub fn validate_claims_without_sets(claims: &[ClaimQuery]) -> Result<(), Validat
 }
 
 /// Validates that the claim IDs in the claims are unique and follow the required format.
-fn validate_claim_ids(claims: &[ClaimQuery]) -> Result<(), ValidationError> {
+fn validate_claim_ids(claims: &[ClaimQuery]) -> Result<(), DcqlClaimsError> {
     let mut seen_ids = std::collections::HashSet::new();
 
     for (i, claim) in claims.iter().enumerate() {
         if let Some(id) = &claim.id {
             if !is_valid_claim_id_format(id) {
-                return Err(ValidationError::new("invalid_claim_id_format")
-                    .with_message(format!("Claim ID '{id}' at index {i} contains invalid characters. Only alphanumeric, underscore, and hyphen characters are allowed").into()));
+                return Err(DcqlClaimsError::InvalidClaimIdFormat(id.clone(), i));
             }
             if id.is_empty() {
-                return Err(ValidationError::new("empty_claim_id")
-                    .with_message(format!("Claim ID cannot be empty at index {i}").into()));
+                return Err(DcqlClaimsError::EmptyClaimId(i));
             }
             if !seen_ids.insert(id) {
-                return Err(ValidationError::new("duplicate_claim_id")
-                    .with_message(format!("Duplicate claim ID '{id}' found at index {i}").into()));
+                return Err(DcqlClaimsError::DuplicateClaimId(id.clone(), i));
             }
         }
     }
@@ -74,12 +83,11 @@ fn validate_claim_ids(claims: &[ClaimQuery]) -> Result<(), ValidationError> {
 }
 
 /// Validates that claim IDs in claim_sets reference valid claims.
-fn validate_claims_sets_references(claim_ids: &[&String], claim_sets: &[Vec<String>]) -> Result<(), ValidationError> {
+fn validate_claims_sets_references(claim_ids: &[&String], claim_sets: &[Vec<String>]) -> Result<(), DcqlClaimsError> {
     for (i, set) in claim_sets.iter().enumerate() {
         for (j, id) in set.iter().enumerate() {
             if !claim_ids.contains(&id) {
-                return Err(ValidationError::new("invalid_claim_id")
-                    .with_message(format!("Claim ID '{id}' not found in claims at claim_set[{i}][{j}]").into()));
+                return Err(DcqlClaimsError::InvalidClaimIdReference(id.clone(), i, j));
             }
         }
     }
@@ -232,7 +240,7 @@ mod tests {
         let result = validate_claims(credential.claims.as_deref().unwrap_or(&[]), &ctx);
         assert!(result.is_err(), "Duplicate IDs found");
         let err = result.unwrap_err();
-        assert_eq!(err.code.as_ref(), "duplicate_claim_id");
+        assert!(matches!(err, DcqlClaimsError::DuplicateClaimId(..)));
     }
 
     #[test]
@@ -247,7 +255,7 @@ mod tests {
         let result = validate_claims(credential.claims.as_deref().unwrap_or(&[]), &ctx);
         assert!(result.is_err(), "IDs are missing but claim_sets are present");
         let err = result.unwrap_err();
-        assert_eq!(err.code.as_ref(), "missing_claim_id");
+        assert!(matches!(err, DcqlClaimsError::MissingClaimId(..)));
     }
 
     #[test]
@@ -262,7 +270,7 @@ mod tests {
         let result = validate_claims(credential.claims.as_deref().unwrap_or(&[]), &ctx);
         assert!(result.is_err(), "Nonexistent ID found in claim_sets");
         let err = result.unwrap_err();
-        assert_eq!(err.code.as_ref(), "invalid_claim_id");
+        assert!(matches!(err, DcqlClaimsError::InvalidClaimIdReference(..)));
     }
 
     #[test]
@@ -275,9 +283,9 @@ mod tests {
             claim_sets: &credential.claim_sets,
         };
 
-        let result: Result<(), ValidationError> = validate_claims(credential.claims.as_deref().unwrap_or(&[]), &ctx);
+        let result: Result<(), DcqlClaimsError> = validate_claims(credential.claims.as_deref().unwrap_or(&[]), &ctx);
         assert!(result.is_err(), "Invalid ID format");
         let err = result.unwrap_err();
-        assert_eq!(err.code.as_ref(), "invalid_claim_id_format");
+        assert!(matches!(err, DcqlClaimsError::InvalidClaimIdFormat(..)));
     }
 }

--- a/oid4vp/src/dcql/dcql_query.rs
+++ b/oid4vp/src/dcql/dcql_query.rs
@@ -1,15 +1,31 @@
-use super::claims::{validate_claims, ClaimsContext};
-use super::meta::{validate_meta, MetaContext};
+use super::claims::{validate_claims, ClaimsContext, DcqlClaimsError};
+use super::meta::{validate_meta, MetaContext, MetaError};
 use nutype::nutype;
 use oid4vc_core::claim_path_pointer::{ClaimPathPointer, ClaimValues};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::collections::HashSet;
-use validator::{Validate, ValidationError, ValidationErrors};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DcqlQueryError {
+    #[error("Duplicate credential ID '{0}' found at index {1}")]
+    DuplicateCredentialId(String, usize),
+    #[error("Credential set options cannot be empty")]
+    EmptyCredentialSetOptions,
+    #[error("Credential set option cannot be empty at option index {0}")]
+    EmptyCredentialSetOption(usize),
+    #[error("Unknown credential query ID '{0}' in credential set option {1}")]
+    UnknownCredentialQueryId(String, usize),
+    #[error("Meta validation failed: {0}")]
+    MetaError(#[from] MetaError),
+    #[error("Claims validation failed: {0}")]
+    ClaimsError(#[from] DcqlClaimsError),
+}
 
 #[nutype(
     validate(not_empty, predicate = valid_credential_query_id),
-    derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash, Eq, Display, AsRef)
+    derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash, Eq, Display, AsRef, FromStr)
 )]
 pub struct CredentialQueryId(String);
 
@@ -17,14 +33,14 @@ fn valid_credential_query_id(s: &str) -> bool {
     s.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-')
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Validate)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct DcqlQuery {
     pub credentials: Vec<CredentialQuery>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub credential_sets: Option<Vec<CredentialSetQuery>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Validate)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct CredentialQuery {
     pub id: CredentialQueryId,
     pub format: Format,
@@ -62,22 +78,18 @@ pub enum Format {
     JwtVcJson,
     #[serde(rename = "dc+sd-jwt")]
     DcSdJwt,
+    #[serde(rename = "vc+sd-jwt")]
+    VcSdJwt,
     MsoMdoc,
 }
 
 impl DcqlQuery {
-    pub fn validate_all(&self) -> Result<(), ValidationErrors> {
-        self.validate()?;
-
+    pub fn validate_all(&self) -> Result<(), DcqlQueryError> {
         // Check for duplicate credential IDs as the same id must not be present in the Authorization Request more than once.
         let mut seen_ids = HashSet::new();
         for (index, credential) in self.credentials.iter().enumerate() {
             if !seen_ids.insert(&credential.id) {
-                let mut errors = ValidationErrors::new();
-                let validation_error = ValidationError::new("duplicate_credential_id")
-                    .with_message(format!("Duplicate credential ID '{}' at index {}", credential.id, index).into());
-                errors.add("credentials", validation_error);
-                return Err(errors);
+                return Err(DcqlQueryError::DuplicateCredentialId(credential.id.to_string(), index));
             }
         }
         for credential in &self.credentials {
@@ -91,123 +103,66 @@ impl DcqlQuery {
         Ok(())
     }
 
-    fn validate_credential_sets(&self, credential_sets: &[CredentialSetQuery]) -> Result<(), ValidationErrors> {
-        let mut errors = ValidationErrors::new();
+    fn validate_credential_sets(&self, credential_sets: &[CredentialSetQuery]) -> Result<(), DcqlQueryError> {
         let credential_ids: HashSet<&CredentialQueryId> = self.credentials.iter().map(|cred| &cred.id).collect();
 
         for credential_set in credential_sets.iter() {
-            if let Err(set_errors) = self.validate_single_credential_set(credential_set, &credential_ids) {
-                for (_, field_errors) in set_errors.field_errors() {
-                    for error in field_errors {
-                        errors.add("credential_sets", error.clone());
-                    }
-                }
-            }
+            self.validate_single_credential_set(credential_set, &credential_ids)?;
         }
 
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
-        }
+        Ok(())
     }
 
     fn validate_single_credential_set(
         &self,
         credential_set: &CredentialSetQuery,
-        credential_ids: &HashSet<&CredentialQueryId>,
-    ) -> Result<(), ValidationErrors> {
-        let mut errors = ValidationErrors::new();
-
+        credential_query_ids: &HashSet<&CredentialQueryId>,
+    ) -> Result<(), DcqlQueryError> {
         // Validate that the options field in credential_set is not empty (as a whole).
         if credential_set.options.is_empty() {
-            let validation_error =
-                ValidationError::new("empty_options").with_message("credential_set options cannot be empty".into());
-            errors.add("options", validation_error);
+            return Err(DcqlQueryError::EmptyCredentialSetOptions);
         }
 
         // Validate that each option in credential_set is not empty.
         for (option_index, option) in credential_set.options.iter().enumerate() {
             if option.is_empty() {
-                let validation_error =
-                    ValidationError::new("empty_option").with_message("options cannot be empty".into());
-                errors.add("options", validation_error);
+                return Err(DcqlQueryError::EmptyCredentialSetOption(option_index));
             }
 
             // Validate that each credential ID in the option exists in the credential arrays.
-            for (credential_index, credential_id_str) in option.iter().enumerate() {
-                match CredentialQueryId::try_new(credential_id_str.clone()) {
-                    Ok(credential_id) => {
-                        if !credential_ids.contains(&credential_id) {
-                            let validation_error = ValidationError::new("unknown_credential_id").with_message(
-                                format!(
-                                    "Credential ID '{}' in option[{}] does not match any known credential ID",
-                                    credential_id_str, option_index
-                                )
-                                .into(),
-                            );
-                            errors.add("options", validation_error);
-                        }
-                    }
-                    Err(_) => {
-                        let validation_error = ValidationError::new("invalid_credential_id_format").with_message(
-                            format!(
-                                "Invalid credential ID format '{}' in options[{}][{}]",
-                                credential_id_str, option_index, credential_index
-                            )
-                            .into(),
-                        );
-                        errors.add("options", validation_error);
-                    }
+            for credential_query_id in option {
+                if !credential_query_ids.contains(&credential_query_id) {
+                    return Err(DcqlQueryError::UnknownCredentialQueryId(
+                        credential_query_id.to_string(),
+                        option_index,
+                    ));
                 }
             }
         }
 
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
-        }
-    }
-}
-
-impl CredentialSetQuery {
-    pub fn validate_all(&self) -> Result<(), ValidationErrors> {
-        self.validate()?;
         Ok(())
     }
 }
 
 impl CredentialQuery {
-    pub fn validate_all(&self) -> Result<(), ValidationErrors> {
-        self.validate()?;
-
+    pub fn validate_all(&self) -> Result<(), DcqlQueryError> {
         let meta_ctx = MetaContext { format: &self.format };
 
-        if let Err(e) = validate_meta(&self.meta, &meta_ctx) {
-            let mut errors = ValidationErrors::new();
-            errors.add("meta", e);
-            return Err(errors);
-        }
+        validate_meta(&self.meta, &meta_ctx)?;
 
         let claims_ctx = ClaimsContext {
             claim_sets: &self.claim_sets,
         };
 
-        if let Err(e) = validate_claims(self.claims.as_deref().unwrap_or(&[]), &claims_ctx) {
-            let mut errors = ValidationErrors::new();
-            errors.add("claims", e);
-            return Err(errors);
-        }
+        validate_claims(self.claims.as_deref().unwrap_or(&[]), &claims_ctx)?;
 
         Ok(())
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Validate)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct CredentialSetQuery {
-    // TODO: Create nutype  with non-empty predicate (see CredentialQueryId)
-    pub options: Vec<Vec<String>>,
+    pub options: Vec<Vec<CredentialQueryId>>,
     #[serde(default = "default_as_true", skip_serializing_if = "Option::is_none")]
     pub required: Option<bool>,
 }
@@ -222,7 +177,7 @@ pub struct TrustedAuthority {
 }
 
 #[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize, PartialEq, Validate, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ClaimQuery {
     // TODO: Use nutype for id, see CredentialQueryId as reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -238,7 +193,7 @@ mod tests {
     use oid4vc_core::claim_path_pointer::{ClaimPathElement, ClaimPathPointer, ClaimValue, ClaimValues};
     use serde_json::from_str;
     // OID4VP Credential Test Examples from
-    // https://github.com/openid/OpenID4VP/tree/main/examples/query_lang
+    // https://github.com/openid/OpenID4VP/tree/main/1.0/examples/query_lang
 
     fn test_credential_query_id(id: &str) -> CredentialQueryId {
         CredentialQueryId::try_new(id.to_string()).unwrap()
@@ -251,6 +206,7 @@ mod tests {
     fn test_claim_values(values: Vec<ClaimValue>) -> ClaimValues {
         ClaimValues::try_new(values).unwrap()
     }
+
     #[test]
     fn test_oid4vp_example_simple_mdoc() {
         assert_eq!(
@@ -646,11 +602,17 @@ mod tests {
                 ],
                 credential_sets: Some(vec![
                     CredentialSetQuery {
-                        options: vec![vec!["mdl-id".to_string()], vec!["photo_card-id".to_string()]],
+                        options: vec![
+                            vec![CredentialQueryId::try_new("mdl-id".to_string()).unwrap()],
+                            vec![CredentialQueryId::try_new("photo_card-id".to_string()).unwrap()]
+                        ],
                         required: Some(true),
                     },
                     CredentialSetQuery {
-                        options: vec![vec!["mdl-address".to_string()], vec!["photo_card-address".to_string()]],
+                        options: vec![
+                            vec![CredentialQueryId::try_new("mdl-address".to_string()).unwrap()],
+                            vec![CredentialQueryId::try_new("photo_card-address".to_string()).unwrap()]
+                        ],
                         required: Some(false),
                     }
                 ])
@@ -798,14 +760,17 @@ mod tests {
                 credential_sets: Some(vec![
                     CredentialSetQuery {
                         options: vec![
-                            vec!["pid".to_string()],
-                            vec!["other_pid".to_string()],
-                            vec!["pid_reduced_cred_1".to_string(), "pid_reduced_cred_2".to_string()]
+                            vec![CredentialQueryId::try_new("pid".to_string()).unwrap()],
+                            vec![CredentialQueryId::try_new("other_pid".to_string()).unwrap()],
+                            vec![
+                                CredentialQueryId::try_new("pid_reduced_cred_1".to_string()).unwrap(),
+                                CredentialQueryId::try_new("pid_reduced_cred_2".to_string()).unwrap()
+                            ]
                         ],
                         required: Some(true)
                     },
                     CredentialSetQuery {
-                        options: vec![vec!["nice_to_have".to_string()]],
+                        options: vec![vec![CredentialQueryId::try_new("nice_to_have".to_string()).unwrap()]],
                         required: Some(false),
                     }
                 ])
@@ -946,25 +911,6 @@ mod tests {
             serde_json::from_value(json).expect("Failed to deserialize CredentialQuery");
 
         assert_eq!(credential_query.require_cryptographic_holder_binding, Some(true))
-    }
-    #[test]
-    fn test_dcql_query() {
-        let temporary = DcqlQuery {
-            credentials: vec![CredentialQuery {
-                id: test_credential_query_id("my_credential"),
-                format: Format::MsoMdoc,
-                multiple: None,
-                meta: MetaTypes::SdJwtMeta {
-                    vct_values: vec!["https://credentials.example.com/identity_credential".to_string()],
-                },
-                trusted_authorities: None,
-                require_cryptographic_holder_binding: Some(true),
-                claims: None,
-                claim_sets: None,
-            }],
-            credential_sets: None,
-        };
-        temporary.validate().unwrap();
     }
 
     #[test]

--- a/oid4vp/src/dcql/dcql_query.rs
+++ b/oid4vp/src/dcql/dcql_query.rs
@@ -196,7 +196,7 @@ mod tests {
     // https://github.com/openid/OpenID4VP/tree/main/1.0/examples/query_lang
 
     fn test_credential_query_id(id: &str) -> CredentialQueryId {
-        CredentialQueryId::try_new(id.to_string()).unwrap()
+        CredentialQueryId::try_new(id).unwrap()
     }
 
     fn test_claim_path(elements: Vec<ClaimPathElement>) -> ClaimPathPointer {
@@ -603,15 +603,15 @@ mod tests {
                 credential_sets: Some(vec![
                     CredentialSetQuery {
                         options: vec![
-                            vec![CredentialQueryId::try_new("mdl-id".to_string()).unwrap()],
-                            vec![CredentialQueryId::try_new("photo_card-id".to_string()).unwrap()]
+                            vec![CredentialQueryId::try_new("mdl-id").unwrap()],
+                            vec![CredentialQueryId::try_new("photo_card-id").unwrap()]
                         ],
                         required: Some(true),
                     },
                     CredentialSetQuery {
                         options: vec![
-                            vec![CredentialQueryId::try_new("mdl-address".to_string()).unwrap()],
-                            vec![CredentialQueryId::try_new("photo_card-address".to_string()).unwrap()]
+                            vec![CredentialQueryId::try_new("mdl-address").unwrap()],
+                            vec![CredentialQueryId::try_new("photo_card-address").unwrap()]
                         ],
                         required: Some(false),
                     }
@@ -760,17 +760,17 @@ mod tests {
                 credential_sets: Some(vec![
                     CredentialSetQuery {
                         options: vec![
-                            vec![CredentialQueryId::try_new("pid".to_string()).unwrap()],
-                            vec![CredentialQueryId::try_new("other_pid".to_string()).unwrap()],
+                            vec![CredentialQueryId::try_new("pid").unwrap()],
+                            vec![CredentialQueryId::try_new("other_pid").unwrap()],
                             vec![
-                                CredentialQueryId::try_new("pid_reduced_cred_1".to_string()).unwrap(),
-                                CredentialQueryId::try_new("pid_reduced_cred_2".to_string()).unwrap()
+                                CredentialQueryId::try_new("pid_reduced_cred_1").unwrap(),
+                                CredentialQueryId::try_new("pid_reduced_cred_2").unwrap()
                             ]
                         ],
                         required: Some(true)
                     },
                     CredentialSetQuery {
-                        options: vec![vec![CredentialQueryId::try_new("nice_to_have".to_string()).unwrap()]],
+                        options: vec![vec![CredentialQueryId::try_new("nice_to_have").unwrap()]],
                         required: Some(false),
                     }
                 ])

--- a/oid4vp/src/dcql/meta.rs
+++ b/oid4vp/src/dcql/meta.rs
@@ -1,37 +1,52 @@
 use super::dcql_query::{Format, MetaTypes};
-use validator::ValidationError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum MetaError {
+    #[error("Meta type {0:?} is not compatible with format {1:?}")]
+    IncompatibleMetaFormat(MetaTypes, Format),
+    #[error("type_values cannot be empty")]
+    EmptyTypeValues,
+    #[error("type_values[{0}] cannot be empty")]
+    EmptyTypeValuesArray(usize),
+    #[error("type_values[{0}][{1}] cannot be empty")]
+    EmptyTypeValuesString(usize, usize),
+    #[error("vct_values cannot be empty")]
+    EmptyVctValues,
+    #[error("vct_values[{0}] cannot be empty")]
+    EmptyVctValuesString(usize),
+    #[error("doctype_value cannot be empty")]
+    EmptyDoctypeValue,
+}
 
 #[derive(Debug)]
 pub struct MetaContext<'a> {
     pub format: &'a Format,
 }
 
-pub fn validate_meta(meta: &MetaTypes, ctx: &MetaContext) -> Result<(), ValidationError> {
+pub fn validate_meta(meta: &MetaTypes, ctx: &MetaContext) -> Result<(), MetaError> {
     match (&ctx.format, meta) {
         (Format::LdpVc, MetaTypes::W3CFormatMeta { type_values }) => validate_w3c_type_values(type_values),
         (Format::JwtVcJson, MetaTypes::W3CFormatMeta { type_values }) => validate_w3c_type_values(type_values),
         (Format::DcSdJwt, MetaTypes::SdJwtMeta { vct_values }) => validate_sd_jwt_vct_values(vct_values),
         (Format::MsoMdoc, MetaTypes::MsoMdocMeta { doctype_value }) => validate_mso_mdoc_doctype(doctype_value),
-        (format, meta) => Err(ValidationError::new("incorrect_meta_format")
-            .with_message(format!("{meta:?} is not compatible with format: {format:?}").into())),
+        (format, meta) => Err(MetaError::IncompatibleMetaFormat(meta.clone(), (*format).clone())),
     }
 }
 
-fn validate_w3c_type_values(type_values: &[Vec<String>]) -> Result<(), ValidationError> {
+fn validate_w3c_type_values(type_values: &[Vec<String>]) -> Result<(), MetaError> {
     if type_values.is_empty() {
-        return Err(ValidationError::new("invalid_type_values").with_message("type_values cannot be empty".into()));
+        return Err(MetaError::EmptyTypeValues);
     }
 
     for (i, inner_array) in type_values.iter().enumerate() {
         if inner_array.is_empty() {
-            return Err(ValidationError::new("invalid_type_values")
-                .with_message(format!("type_values[{i}] cannot be empty").into()));
+            return Err(MetaError::EmptyTypeValuesArray(i));
         }
 
         for (j, value) in inner_array.iter().enumerate() {
             if value.is_empty() {
-                return Err(ValidationError::new("invalid_type_values")
-                    .with_message(format!("type_values[{i}][{j}] cannot be empty").into()));
+                return Err(MetaError::EmptyTypeValuesString(i, j));
             }
         }
     }
@@ -39,24 +54,23 @@ fn validate_w3c_type_values(type_values: &[Vec<String>]) -> Result<(), Validatio
     Ok(())
 }
 
-fn validate_sd_jwt_vct_values(vct_values: &[String]) -> Result<(), ValidationError> {
+fn validate_sd_jwt_vct_values(vct_values: &[String]) -> Result<(), MetaError> {
     if vct_values.is_empty() {
-        return Err(ValidationError::new("invalid_vct_values").with_message("vct_values cannot be empty".into()));
+        return Err(MetaError::EmptyVctValues);
     }
 
     for (i, value) in vct_values.iter().enumerate() {
         if value.is_empty() {
-            return Err(ValidationError::new("invalid_vct_values")
-                .with_message(format!("vct_values[{i}] cannot be empty").into()));
+            return Err(MetaError::EmptyVctValuesString(i));
         }
     }
 
     Ok(())
 }
 
-fn validate_mso_mdoc_doctype(doctype_value: &str) -> Result<(), ValidationError> {
+fn validate_mso_mdoc_doctype(doctype_value: &str) -> Result<(), MetaError> {
     if doctype_value.is_empty() {
-        return Err(ValidationError::new("invalid_doctype_value").with_message("doctype_value cannot be empty".into()));
+        return Err(MetaError::EmptyDoctypeValue);
     }
 
     Ok(())

--- a/oid4vp/src/dcql_evaluation.rs
+++ b/oid4vp/src/dcql_evaluation.rs
@@ -90,71 +90,73 @@ pub fn evaluate_credential_query(
         return true;
     }
 
-    // TODO: How do we handle multiple presentations when the `multiple` claim is `true`?
-    let decoded_presentation = if let Some(decoded_presentation) = decoded_presentations.first() {
-        decoded_presentation
-    } else {
+    // If `multiple` is `false`, the Verifier is requesting that only one presentation of a Credential matching the Credential Query be returned.
+    if !credential_query.multiple.unwrap_or_default() && decoded_presentations.len() > 1 {
         return false;
-    };
+    }
 
-    // If meta is present, check the meta requirements.
-    match &credential_query.meta {
-        MetaTypes::W3CFormatMeta { type_values } => {
-            // For W3C Verifiable Credentials, check the "type" field in the credential
-            if let Some(credential_types) = decoded_presentation.get("type").and_then(|t| t.as_array()) {
-                let credential_type_strings: Vec<&str> = credential_types.iter().filter_map(|t| t.as_str()).collect();
+    decoded_presentations.iter().any(|decoded_presentation| {
+        // If meta is present, check the meta requirements.
+        match &credential_query.meta {
+            MetaTypes::W3CFormatMeta { type_values } => {
+                // For W3C Verifiable Credentials, check the "type" field in the credential
+                if let Some(credential_types) = decoded_presentation.get("type").and_then(|t| t.as_array()) {
+                    let credential_type_strings: Vec<&str> =
+                        credential_types.iter().filter_map(|t| t.as_str()).collect();
 
-                // Check if any of the type_values arrays is a subset of the credential's types
-                let type_match = type_values.iter().any(|type_option| {
-                    type_option
-                        .iter()
-                        .all(|required_type| credential_type_strings.contains(&required_type.as_str()))
-                });
+                    // Check if any of the type_values arrays is a subset of the credential's types
+                    let type_match = type_values.iter().any(|type_option| {
+                        type_option
+                            .iter()
+                            .all(|required_type| credential_type_strings.contains(&required_type.as_str()))
+                    });
 
-                if !type_match {
+                    if !type_match {
+                        return false;
+                    }
+                } else {
                     return false;
                 }
-            } else {
-                return false;
+            }
+            MetaTypes::SdJwtMeta {
+                vct_values: _vct_values,
+            } => {
+                // TODO: Implement SD-JWT `vct` checking
+            }
+            MetaTypes::MsoMdocMeta {
+                doctype_value: _doctype_value,
+            } => {
+                // TODO: Implement MSO mDoc type checking
             }
         }
-        MetaTypes::SdJwtMeta {
-            vct_values: _vct_values,
-        } => {
-            // TODO: Implement SD-JWT `vct` checking
-        }
-        MetaTypes::MsoMdocMeta {
-            doctype_value: _doctype_value,
-        } => {
-            // TODO: Implement MSO mDoc type checking
-        }
-    }
 
-    // TODO: Check `trusted_authorities` if present
-    // TODO: Check `require_cryptographic_holder_binding`
+        // TODO: Check `trusted_authorities` if present
+        // TODO: Check `require_cryptographic_holder_binding`
 
-    // If claims is present, but claim_sets is absent, the Verifier requests all claims listed in claims.
-    match &credential_query.claim_sets {
-        None => {
-            credential_query.claims.as_deref().unwrap_or(&[]).iter().all(|claim| {
-                evaluate_single_claim_query(claim, &serde_json::Value::Object(decoded_presentation.clone()))
-            })
+        let presentation_value = serde_json::Value::Object(decoded_presentation.clone());
+
+        // If claims is present, but claim_sets is absent, the Verifier requests all claims listed in claims.
+        match &credential_query.claim_sets {
+            None => credential_query
+                .claims
+                .as_deref()
+                .unwrap_or(&[])
+                .iter()
+                .all(|claim| evaluate_single_claim_query(claim, &presentation_value)),
+
+            // If both claims and claim_sets are present, the Verifier requests one combination of the claims listed in claim_sets. The order of the options conveyed in the claim_sets array expresses the Verifier's preference for what is returned;
+            // the Wallet SHOULD return the first option that it can satisfy. If the Wallet cannot satisfy any of the options, it MUST NOT return any claims.
+            Some(claim_sets) => claim_sets.iter().any(|claim_set| {
+                claim_set.iter().all(|claim_id| {
+                    credential_query
+                        .claims
+                        .as_ref()
+                        .and_then(|claims| claims.iter().find(|claim| claim.id.as_ref() == Some(claim_id)))
+                        .is_some_and(|claim| evaluate_single_claim_query(claim, &presentation_value))
+                })
+            }),
         }
-
-        // If both claims and claim_sets are present, the Verifier requests one combination of the claims listed in claim_sets. The order of the options conveyed in the claim_sets array expresses the Verifier's preference for what is returned;
-        // the Wallet SHOULD return the first option that it can satisfy. If the Wallet cannot satisfy any of the options, it MUST NOT return any claims.
-        Some(claim_sets) => claim_sets.iter().any(|claim_set| {
-            claim_set.iter().all(|claim_id| {
-                credential_query
-                    .claims
-                    .as_ref()
-                    .and_then(|claims| claims.iter().find(|claim| claim.id.as_ref() == Some(claim_id)))
-                    .is_some_and(|claim| {
-                        evaluate_single_claim_query(claim, &serde_json::Value::Object(decoded_presentation.clone()))
-                    })
-            })
-        }),
-    }
+    })
 }
 
 pub fn matches_claim_values(actual_value: &Value, required_value: &ClaimValues) -> bool {

--- a/oid4vp/src/dcql_evaluation.rs
+++ b/oid4vp/src/dcql_evaluation.rs
@@ -1,15 +1,17 @@
-use crate::dcql::dcql_query::{ClaimQuery, CredentialQuery, CredentialSetQuery, DcqlQuery, MetaTypes};
+use crate::{
+    dcql::dcql_query::{ClaimQuery, CredentialQuery, CredentialSetQuery, DcqlQuery, MetaTypes},
+    token::vp_token_validator::{DecodedPresentations, DecodedVpToken},
+};
 use oid4vc_core::claim_path_pointer::{ClaimValue, ClaimValues};
 use serde_json::Value;
-use std::collections::HashMap;
 
-/// Processing a dcql_query with credential sets as described in OID4VP - draft 28 - Section 6.4.2 Selecting Credentials:
+/// Processing a dcql_query with credential sets as described in OID4VP - Section 6.4.2 Selecting Credentials:
 /// https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-selecting-credentials
 fn set_is_required(credential_set: &CredentialSetQuery) -> bool {
     credential_set.required.unwrap_or(true)
 }
 
-pub fn evaluate_dcql_query(dcql_query: &DcqlQuery, available_credentials: &HashMap<String, &Value>) -> bool {
+pub fn evaluate_dcql_query(dcql_query: &DcqlQuery, decoded_vp_token: &DecodedVpToken) -> bool {
     // If there are credential sets, check if all required sets can be satisfied.
     if let Some(credential_sets) = &dcql_query.credential_sets {
         // All of the Credential Set Queries in the credential_sets array where
@@ -21,7 +23,7 @@ pub fn evaluate_dcql_query(dcql_query: &DcqlQuery, available_credentials: &HashM
             }
 
             // Check if the required set has at least one satisfiable option.
-            evaluate_credential_set(credential_set, &dcql_query.credentials, available_credentials)
+            evaluate_credential_set(credential_set, &dcql_query.credentials, decoded_vp_token)
         });
 
         return required_sets_satisfied;
@@ -29,9 +31,8 @@ pub fn evaluate_dcql_query(dcql_query: &DcqlQuery, available_credentials: &HashM
 
     // If credential_sets is not provided, the Verifier requests presentations for all Credentials in credentials to be returned.
     dcql_query.credentials.iter().all(|credential_query| {
-        let credential_id = credential_query.id.as_ref();
-        if let Some(credential_json) = available_credentials.get(credential_id) {
-            evaluate_credential_query(credential_query, credential_json)
+        if let Some(decoded_presentations) = decoded_vp_token.decoded_presentations().get(&credential_query.id) {
+            evaluate_credential_query(credential_query, decoded_presentations)
         } else {
             false
         }
@@ -43,12 +44,12 @@ pub fn evaluate_dcql_query(dcql_query: &DcqlQuery, available_credentials: &HashM
 pub fn evaluate_credential_set(
     credential_set: &CredentialSetQuery,
     all_credentials: &[CredentialQuery],
-    available_credentials: &HashMap<String, &Value>,
+    available_credentials: &DecodedVpToken,
 ) -> bool {
     credential_set.options.iter().any(|option| {
-        option.iter().all(|credential_id| {
-            if let Some(credential_query) = all_credentials.iter().find(|cq| cq.id.as_ref() == credential_id) {
-                if let Some(credential_json) = available_credentials.get(credential_id) {
+        option.iter().all(|credential_query_id| {
+            if let Some(credential_query) = all_credentials.iter().find(|cq| cq.id == *credential_query_id) {
+                if let Some(credential_json) = available_credentials.decoded_presentations().get(credential_query_id) {
                     evaluate_credential_query(credential_query, credential_json)
                 } else {
                     false
@@ -77,20 +78,30 @@ fn evaluate_single_claim_query(claim_query: &ClaimQuery, credential_json: &Value
     true
 }
 
-/// Processing with claims_sets as described in OID4VP - draft 28 Section 6.4.1 Selecting Claims:
+/// Processing with claims_sets as described in OID4VP Section 6.4.1 Selecting Claims:
 /// https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-selecting-claims
-pub fn evaluate_credential_query(credential_query: &CredentialQuery, credential_json: &Value) -> bool {
+pub fn evaluate_credential_query(
+    credential_query: &CredentialQuery,
+    decoded_presentations: &DecodedPresentations,
+) -> bool {
     // If claims is absent, the Verifier is requesting no claims that are selectively disclosable;
     // the Wallet MUST return only the claims that are mandatory to present (e.g., SD-JWT and Key Binding JWT for a Credential of format IETF SD-JWT VC).
     if credential_query.claims.as_deref().unwrap_or(&[]).is_empty() {
         return true;
     }
 
+    // TODO: How do we handle multiple presentations when the `multiple` claim is `true`?
+    let decoded_presentation = if let Some(decoded_presentation) = decoded_presentations.first() {
+        decoded_presentation
+    } else {
+        return false;
+    };
+
     // If meta is present, check the meta requirements.
     match &credential_query.meta {
         MetaTypes::W3CFormatMeta { type_values } => {
             // For W3C Verifiable Credentials, check the "type" field in the credential
-            if let Some(credential_types) = credential_json.get("type").and_then(|t| t.as_array()) {
+            if let Some(credential_types) = decoded_presentation.get("type").and_then(|t| t.as_array()) {
                 let credential_type_strings: Vec<&str> = credential_types.iter().filter_map(|t| t.as_str()).collect();
 
                 // Check if any of the type_values arrays is a subset of the credential's types
@@ -124,12 +135,11 @@ pub fn evaluate_credential_query(credential_query: &CredentialQuery, credential_
 
     // If claims is present, but claim_sets is absent, the Verifier requests all claims listed in claims.
     match &credential_query.claim_sets {
-        None => credential_query
-            .claims
-            .as_deref()
-            .unwrap_or(&[])
-            .iter()
-            .all(|claim| evaluate_single_claim_query(claim, credential_json)),
+        None => {
+            credential_query.claims.as_deref().unwrap_or(&[]).iter().all(|claim| {
+                evaluate_single_claim_query(claim, &serde_json::Value::Object(decoded_presentation.clone()))
+            })
+        }
 
         // If both claims and claim_sets are present, the Verifier requests one combination of the claims listed in claim_sets. The order of the options conveyed in the claim_sets array expresses the Verifier's preference for what is returned;
         // the Wallet SHOULD return the first option that it can satisfy. If the Wallet cannot satisfy any of the options, it MUST NOT return any claims.
@@ -139,7 +149,9 @@ pub fn evaluate_credential_query(credential_query: &CredentialQuery, credential_
                     .claims
                     .as_ref()
                     .and_then(|claims| claims.iter().find(|claim| claim.id.as_ref() == Some(claim_id)))
-                    .is_some_and(|claim| evaluate_single_claim_query(claim, credential_json))
+                    .is_some_and(|claim| {
+                        evaluate_single_claim_query(claim, &serde_json::Value::Object(decoded_presentation.clone()))
+                    })
             })
         }),
     }
@@ -156,7 +168,10 @@ pub fn matches_claim_values(actual_value: &Value, required_value: &ClaimValues) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dcql::claims::{validate_claims, ClaimsContext};
+    use crate::{
+        dcql::claims::{validate_claims, ClaimsContext},
+        token::vp_token_validator::DecodedVpTokenBuilder,
+    };
     use oid4vc_core::claim_path_pointer::{ClaimPathElement, ClaimPathPointer, ClaimValue, ClaimValues};
     use serde_json::json;
 
@@ -169,12 +184,11 @@ mod tests {
     fn test_get_value_from_json() {
         let testing_credential: Value = serde_json::from_str(TESTCREDENTIAL).unwrap();
         let path = ClaimPathPointer::try_new(vec![
-            ClaimPathElement::String("vc".to_string()),
             ClaimPathElement::String("credentialSubject".to_string()),
             ClaimPathElement::String("given_name".to_string()),
         ])
         .unwrap();
-        let values = path.get_values_from_json(&testing_credential);
+        let values = path.get_values_from_json(&testing_credential["vc"]);
         assert_eq!(values, vec![json!("Max")]);
     }
 
@@ -184,7 +198,6 @@ mod tests {
         let claim_query = ClaimQuery {
             id: Some("given_name".to_string()),
             path: ClaimPathPointer::try_new(vec![
-                ClaimPathElement::String("vc".to_string()),
                 ClaimPathElement::String("credentialSubject".to_string()),
                 ClaimPathElement::String("given_name".to_string()),
             ])
@@ -192,7 +205,7 @@ mod tests {
             values: Some(ClaimValues::try_new(vec![ClaimValue::String("Max".to_string())]).unwrap()),
         };
         // Returns true
-        assert!(evaluate_single_claim_query(&claim_query, &testing_credential));
+        assert!(evaluate_single_claim_query(&claim_query, &testing_credential["vc"]));
     }
 
     #[test]
@@ -278,7 +291,8 @@ mod tests {
 
         assert!(evaluate_credential_query(
             dcql_query,
-            &testing_credential.get("vc").unwrap()
+            &DecodedPresentations::try_new(vec![testing_credential.get("vc").unwrap().as_object().unwrap().clone()])
+                .unwrap()
         ));
     }
 
@@ -332,7 +346,8 @@ mod tests {
         // Assert `false` because the credential type does not match the required type in the query.
         assert!(!evaluate_credential_query(
             dcql_query,
-            &testing_credential.get("vc").unwrap()
+            &DecodedPresentations::try_new(vec![testing_credential.get("vc").unwrap().as_object().unwrap().clone()])
+                .unwrap()
         ));
     }
 
@@ -349,10 +364,16 @@ mod tests {
             }
         });
 
-        let mut available_credentials = HashMap::new();
-        available_credentials.insert("pid".to_string(), &pid_credential);
+        let mut builder = DecodedVpTokenBuilder::new();
 
-        assert!(evaluate_dcql_query(&dcql_query, &available_credentials));
+        builder = builder
+            .insert(
+                "pid".parse().unwrap(),
+                vec![pid_credential.as_object().unwrap().clone()],
+            )
+            .unwrap();
+
+        assert!(evaluate_dcql_query(&dcql_query, &builder.build()));
 
         // Alternative credentials (pid_reduced_cred_1 + pid_reduced_cred_2)
         let reduced_cred_1 = json!({
@@ -366,15 +387,25 @@ mod tests {
             "region": "HERE"
         });
 
-        let mut available_credentials = HashMap::new();
-        available_credentials.insert("pid_reduced_cred_1".to_string(), &reduced_cred_1);
-        available_credentials.insert("pid_reduced_cred_2".to_string(), &reduced_cred_2);
+        let mut builder = DecodedVpTokenBuilder::new();
+        builder = builder
+            .insert(
+                "pid_reduced_cred_1".parse().unwrap(),
+                vec![reduced_cred_1.as_object().unwrap().clone()],
+            )
+            .unwrap();
+        builder = builder
+            .insert(
+                "pid_reduced_cred_2".parse().unwrap(),
+                vec![reduced_cred_2.as_object().unwrap().clone()],
+            )
+            .unwrap();
 
-        assert!(evaluate_dcql_query(&dcql_query, &available_credentials));
+        assert!(evaluate_dcql_query(&dcql_query, &builder.build()));
 
         // If there were no credentials, the query should fail.
-        let available_credentials = HashMap::new();
+        let builder = DecodedVpTokenBuilder::new();
 
-        assert!(!evaluate_dcql_query(&dcql_query, &available_credentials));
+        assert!(!evaluate_dcql_query(&dcql_query, &builder.build()));
     }
 }

--- a/oid4vp/src/oid4vp.rs
+++ b/oid4vp/src/oid4vp.rs
@@ -1,23 +1,19 @@
 use crate::authorization_request::{
     AuthorizationRequestBuilder, AuthorizationRequestParameters, ClientMetadataParameters,
 };
-use crate::dcql::dcql_query::CredentialQueryId;
-use crate::token::verifiable_presentation_jwt::VerifiablePresentationJwt;
-use crate::token::vp_token::{PresentationFormat, VpToken};
+use crate::token::vp_token::VpToken;
+use crate::token::vp_token_validator::DecodedVpToken;
 use anyhow::anyhow;
-use futures::future::join_all;
 use jsonwebtoken::Algorithm;
 use oid4vc_core::client_metadata::ClientMetadataResource;
 use oid4vc_core::openid4vc_extension::{OpenID4VC, RequestHandle, ResponseHandle};
 use oid4vc_core::Subject;
 use oid4vc_core::SubjectSyntaxType;
 use oid4vc_core::{authorization_response::AuthorizationResponse, openid4vc_extension::Extension};
-use oid4vci::VerifiableCredentialJwt;
 use reqwest_middleware::ClientBuilder;
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::RetryTransientMiddleware;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -41,40 +37,6 @@ impl ResponseHandle for ResponseHandler {
     type Input = VpToken;
     type Parameters = AuthorizationResponseParameters;
     type ResponseItem = DecodedVpToken;
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-pub struct DecodedVpToken {
-    #[serde(flatten)]
-    pub presentations: HashMap<CredentialQueryId, Vec<VerifiablePresentationJwt>>,
-}
-
-impl DecodedVpToken {
-    // The Verifier MUST validate every individual Verifiable Presentation in an Authorization Response
-    // and ensure that it is linked to the values of the client_id and the nonce parameter it had used for the respective Authorization Request.
-    // If any Verifiable Presentation in the response does not contain the correct nonce value, the response MUST be rejected.
-    pub fn validate_nonce(&self, expected_nonce: &str) -> Result<(), String> {
-        for (credential_query_id, presentations) in &self.presentations {
-            for (index, vp) in presentations.iter().enumerate() {
-                match vp.nonce() {
-                    Some(nonce) if nonce != expected_nonce => {
-                        return Err(format!(
-                            "Nonce mismatch in VP for credential query ID {:?} at index {}",
-                            credential_query_id, index
-                        ))
-                    }
-                    None => {
-                        return Err(format!(
-                            "Missing nonce in VP for credential query ID {:?} at index {}",
-                            credential_query_id, index
-                        ))
-                    }
-                    Some(_) => {}
-                }
-            }
-        }
-        Ok(())
-    }
 }
 
 /// This is the [`Extension`] implementation for the [`OID4VP`] extension.
@@ -193,49 +155,6 @@ impl Extension for OID4VP {
             redirect_uri,
             state,
             extension: AuthorizationResponseParameters { vp_token: user_input },
-        })
-    }
-
-    async fn decode_authorization_response(
-        validator: oid4vc_core::Validator,
-        authorization_response: &AuthorizationResponse<Self>,
-    ) -> anyhow::Result<DecodedVpToken> {
-        let vp_token = &authorization_response.extension.vp_token;
-        let mut decoded_presentations: HashMap<CredentialQueryId, Vec<VerifiablePresentationJwt>> = HashMap::new();
-        for (credential_query_id, presentation_formats) in vp_token.presentations() {
-            let mut all_decoded_vps = Vec::new();
-            for presentation_format in presentation_formats {
-                match presentation_format {
-                    PresentationFormat::JwtVcJson(jwt_string) => {
-                        // Decode the vp envelope
-                        let decoded_vp: VerifiablePresentationJwt = validator.decode(jwt_string.clone()).await?;
-
-                        // Verify the credentials inside the vp
-                        let inner_vcs = decoded_vp.verifiable_presentation().verifiable_credential.iter();
-
-                        let credential_futures: Vec<_> = inner_vcs
-                            .map(|vc_jwt| validator.decode::<VerifiableCredentialJwt>(vc_jwt.as_str().to_owned()))
-                            .collect();
-
-                        // If any of the inner VCs fail, throw an error.
-                        let _verified_inner_vcs: Vec<VerifiableCredentialJwt> = join_all(credential_futures)
-                            .await
-                            .into_iter()
-                            .collect::<Result<_, _>>()?;
-
-                        all_decoded_vps.push(decoded_vp);
-                    }
-                    // TODO: handle additional formats DcSdJwt, LdpVc and MsoMdoc
-                    _ => {
-                        return Err(anyhow!("Unsupported presentation format: {:?}", presentation_format));
-                    }
-                }
-            }
-            decoded_presentations.insert(credential_query_id.clone(), all_decoded_vps);
-        }
-
-        Ok(DecodedVpToken {
-            presentations: decoded_presentations,
         })
     }
 }

--- a/oid4vp/src/token/mod.rs
+++ b/oid4vp/src/token/mod.rs
@@ -2,3 +2,4 @@ pub mod verifiable_presentation_jwt;
 pub mod verifiable_presentation_jwt_builder;
 pub mod vp_token;
 pub mod vp_token_builder;
+pub mod vp_token_validator;

--- a/oid4vp/src/token/verifiable_presentation_jwt.rs
+++ b/oid4vp/src/token/verifiable_presentation_jwt.rs
@@ -1,25 +1,25 @@
 use super::verifiable_presentation_jwt_builder::VerifiablePresentationJwtBuilder;
 use getset::Getters;
-use identity_credential::{credential::Jwt, presentation::Presentation};
+use identity_credential::presentation::Presentation;
 use oid4vc_core::RFC7519Claims;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_with::skip_serializing_none;
 
 #[skip_serializing_none]
-#[derive(Serialize, Clone, Deserialize, Debug, Getters, PartialEq)]
-pub struct VerifiablePresentationJwt {
+#[derive(Serialize, Clone, Debug, Getters, PartialEq)]
+pub struct VerifiablePresentationJwt<CRED> {
     #[serde(flatten)]
     #[getset(get = "pub")]
     pub(super) rfc7519_claims: RFC7519Claims,
     #[serde(rename = "vp")]
     #[getset(get = "pub")]
-    pub(super) verifiable_presentation: Presentation<Jwt>,
+    pub(super) verifiable_presentation: Presentation<CRED>,
     #[getset(get = "pub")]
     pub(super) nonce: Option<String>,
 }
 
-impl VerifiablePresentationJwt {
-    pub fn builder() -> VerifiablePresentationJwtBuilder {
+impl<CRED> VerifiablePresentationJwt<CRED> {
+    pub fn builder() -> VerifiablePresentationJwtBuilder<CRED> {
         VerifiablePresentationJwtBuilder::new()
     }
 }

--- a/oid4vp/src/token/verifiable_presentation_jwt_builder.rs
+++ b/oid4vp/src/token/verifiable_presentation_jwt_builder.rs
@@ -1,21 +1,30 @@
 use super::verifiable_presentation_jwt::VerifiablePresentationJwt;
 use anyhow::{anyhow, Result};
-use identity_credential::{credential::Jwt, presentation::Presentation};
+use identity_credential::presentation::Presentation;
 use oid4vc_core::{builder_fn, RFC7519Claims};
 
-#[derive(Default)]
-pub struct VerifiablePresentationJwtBuilder {
+pub struct VerifiablePresentationJwtBuilder<CRED> {
     rfc7519_claims: RFC7519Claims,
-    verifiable_presentation: Option<Presentation<Jwt>>,
+    verifiable_presentation: Option<Presentation<CRED>>,
     nonce: Option<String>,
 }
 
-impl VerifiablePresentationJwtBuilder {
+impl<CRED> Default for VerifiablePresentationJwtBuilder<CRED> {
+    fn default() -> Self {
+        Self {
+            rfc7519_claims: RFC7519Claims::default(),
+            verifiable_presentation: None,
+            nonce: None,
+        }
+    }
+}
+
+impl<CRED> VerifiablePresentationJwtBuilder<CRED> {
     pub fn new() -> Self {
-        VerifiablePresentationJwtBuilder::default()
+        VerifiablePresentationJwtBuilder::<CRED>::default()
     }
 
-    pub fn build(self) -> Result<VerifiablePresentationJwt> {
+    pub fn build(self) -> Result<VerifiablePresentationJwt<CRED>> {
         anyhow::ensure!(self.rfc7519_claims.iss.is_some(), "iss claim is required");
         anyhow::ensure!(self.rfc7519_claims.sub.is_some(), "sub claim is required");
         // TODO: According to https://openid.net/specs/openid-connect-core-1_0.html#IDToken, the sub claim MUST NOT
@@ -49,6 +58,6 @@ impl VerifiablePresentationJwtBuilder {
     builder_fn!(rfc7519_claims, nbf, i64);
     builder_fn!(rfc7519_claims, iat, i64);
     builder_fn!(rfc7519_claims, jti, String);
-    builder_fn!(verifiable_presentation, Presentation<Jwt>);
+    builder_fn!(verifiable_presentation, Presentation<CRED>);
     builder_fn!(nonce, String);
 }

--- a/oid4vp/src/token/vp_token.rs
+++ b/oid4vp/src/token/vp_token.rs
@@ -1,6 +1,9 @@
 use super::vp_token_builder::VpTokenBuilder;
 use crate::dcql::dcql_query::CredentialQueryId;
 use getset::Getters;
+use nutype::nutype;
+use oid4vc_core::types::string_or_object::StringOrObject;
+use oid4vc_core::utils::predicates::not_empty;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -8,16 +11,7 @@ use std::collections::HashMap;
 pub struct VpToken {
     #[serde(flatten)]
     #[getset(get = "pub")]
-    pub(super) presentations: HashMap<CredentialQueryId, Vec<PresentationFormat>>,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-#[serde(untagged)]
-pub enum PresentationFormat {
-    LdpVc,
-    JwtVcJson(String),
-    DcSdJwt(String),
-    MsoMdoc(Vec<u8>),
+    pub(super) presentations: HashMap<CredentialQueryId, Presentations>,
 }
 
 impl VpToken {
@@ -25,3 +19,9 @@ impl VpToken {
         VpTokenBuilder::new()
     }
 }
+
+#[nutype(
+    validate(predicate = not_empty),
+    derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Deref)
+)]
+pub struct Presentations(Vec<StringOrObject>);

--- a/oid4vp/src/token/vp_token_builder.rs
+++ b/oid4vp/src/token/vp_token_builder.rs
@@ -141,11 +141,11 @@ mod tests {
         // Test: Add presentation for credential that wasn't requested
         let result = VpTokenBuilder::builder_dcql_query(dcql_query)
             .add_presentations(
-                CredentialQueryId::try_new("requested-cred".to_string()).unwrap(),
+                CredentialQueryId::try_new("requested-cred").unwrap(),
                 Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .add_presentations(
-                CredentialQueryId::try_new("unrequested-cred".to_string()).unwrap(),
+                CredentialQueryId::try_new("unrequested-cred").unwrap(),
                 Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .build();
@@ -196,7 +196,7 @@ mod tests {
         // Provide only required credential, skip optional (should pass)
         let result = VpTokenBuilder::builder_dcql_query(dcql_query)
             .add_presentations(
-                CredentialQueryId::try_new("mdl-id".to_string()).unwrap(),
+                CredentialQueryId::try_new("mdl-id").unwrap(),
                 Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .build();
@@ -242,12 +242,12 @@ mod tests {
 
         let result = VpTokenBuilder::builder_dcql_query(dcql_query)
             .add_presentations(
-                CredentialQueryId::try_new("mdl-id".to_string()).unwrap(),
+                CredentialQueryId::try_new("mdl-id").unwrap(),
                 Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .add_presentations(
                 // This credential is unrequested and should cause an error
-                CredentialQueryId::try_new("thats-not-right".to_string()).unwrap(),
+                CredentialQueryId::try_new("thats-not-right").unwrap(),
                 Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .build();
@@ -295,11 +295,11 @@ mod tests {
 
         let result = VpTokenBuilder::builder_dcql_query(dcql_query)
             .add_presentations(
-                CredentialQueryId::try_new("mdl-id".to_string()).unwrap(),
+                CredentialQueryId::try_new("mdl-id").unwrap(),
                 Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .add_presentations(
-                CredentialQueryId::try_new("optional-cred".to_string()).unwrap(),
+                CredentialQueryId::try_new("optional-cred").unwrap(),
                 Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .build();
@@ -394,11 +394,11 @@ mod tests {
 
         let result = VpTokenBuilder::builder_dcql_query(dcql_query)
             .add_presentations(
-                CredentialQueryId::try_new("unrequested-cred".to_string()).unwrap(),
+                CredentialQueryId::try_new("unrequested-cred").unwrap(),
                 Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .add_presentations(
-                CredentialQueryId::try_new("optional-cred".to_string()).unwrap(),
+                CredentialQueryId::try_new("optional-cred").unwrap(),
                 Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .build();

--- a/oid4vp/src/token/vp_token_builder.rs
+++ b/oid4vp/src/token/vp_token_builder.rs
@@ -1,12 +1,24 @@
 use crate::dcql::dcql_query::{CredentialQuery, CredentialQueryId, DcqlQuery};
-use crate::token::vp_token::{PresentationFormat, VpToken};
+use crate::token::vp_token::{Presentations, VpToken};
 use anyhow::Result;
 use std::collections::HashMap;
-use validator::{Validate, ValidationError, ValidationErrors};
+use thiserror::Error;
 
-#[derive(Default, Validate)]
+#[derive(Debug, Error)]
+pub enum VpTokenBuilderError {
+    #[error("Required credential set not satisfied: {0:?}")]
+    RequiredCredentialSetNotSatisfied(crate::dcql::dcql_query::CredentialSetQuery),
+    #[error("Missing required credential: {0}")]
+    MissingRequiredCredential(CredentialQueryId),
+    #[error("Unrequested credential: {0}")]
+    UnrequestedCredential(CredentialQueryId),
+    #[error("Multiple presentations not allowed for credential: {0}")]
+    MultipleNotAllowed(CredentialQueryId),
+}
+
+#[derive(Default)]
 pub struct VpTokenBuilder {
-    presentations: HashMap<CredentialQueryId, Vec<PresentationFormat>>,
+    presentations: HashMap<CredentialQueryId, Presentations>,
     dcql_query: Option<DcqlQuery>,
 }
 
@@ -22,25 +34,14 @@ impl VpTokenBuilder {
         }
     }
 
-    pub fn add_presentation(mut self, credential_id: CredentialQueryId, presentation: PresentationFormat) -> Self {
-        self.presentations.entry(credential_id).or_default().push(presentation);
-        self
-    }
-
     // for multiple presentations for the same credential_id
-    pub fn add_presentations(
-        mut self,
-        credential_id: CredentialQueryId,
-        presentations: Vec<PresentationFormat>,
-    ) -> Self {
+    pub fn add_presentations(mut self, credential_id: CredentialQueryId, presentations: Presentations) -> Self {
         self.presentations.insert(credential_id, presentations);
         self
     }
 
-    pub fn build(self) -> Result<VpToken, ValidationErrors> {
-        self.validate()?;
+    pub fn build(self) -> Result<VpToken, VpTokenBuilderError> {
         if let Some(ref dcql_query) = self.dcql_query {
-            dcql_query.validate()?;
             self.validate_against_dcql(dcql_query)?;
         }
 
@@ -49,59 +50,65 @@ impl VpTokenBuilder {
         })
     }
 
-    // Validate the VpToken against the provided DcqlQuery.
-    fn validate_against_dcql(&self, dcql_query: &DcqlQuery) -> Result<(), ValidationErrors> {
-        let mut errors = ValidationErrors::new();
+    /// Validate the presentations against the DCQL query's requirements (credential sets, multiple constraints, unrequested credentials).
+    fn validate_against_dcql(&self, dcql_query: &DcqlQuery) -> Result<(), VpTokenBuilderError> {
+        validate_presentation_submission(&self.presentations, dcql_query)
+    }
+}
 
-        let credential_queries: HashMap<CredentialQueryId, &CredentialQuery> =
-            dcql_query.credentials.iter().map(|cq| (cq.id.clone(), cq)).collect();
+/// Validates that the provided map of presentations satisfies the structural requirements
+/// of the DCQL query (required sets, multiple constraints, unrequested credentials).
+pub fn validate_presentation_submission(
+    presentations: &HashMap<CredentialQueryId, Presentations>,
+    dcql_query: &DcqlQuery,
+) -> Result<(), VpTokenBuilderError> {
+    let credential_queries: HashMap<CredentialQueryId, &CredentialQuery> =
+        dcql_query.credentials.iter().map(|cq| (cq.id.clone(), cq)).collect();
 
-        if let Some(credential_sets) = &dcql_query.credential_sets {
-            // Check if all required credential sets are satisfied.
-            for credential_set in credential_sets {
-                if credential_set.required.unwrap_or(true) && !self.is_credential_set_satisfied(credential_set) {
-                    errors.add(
-                        "credential_sets",
-                        ValidationError::new("required_credential_set_not_satisfied"),
-                    );
-                }
-            }
-        } else {
-            // If there are no credential sets, we assume all credentials are required.
-            for credential_query in &dcql_query.credentials {
-                if !self.presentations.contains_key(&credential_query.id) {
-                    errors.add("presentations", ValidationError::new("missing_required_credential"));
-                }
-            }
-        }
-        // Check multiple constraints and for no unrequested presentations
-        for (credential_id, presentations) in &self.presentations {
-            if let Some(credential_query) = credential_queries.get(credential_id) {
-                if !credential_query.multiple.unwrap_or(false) && presentations.len() > 1 {
-                    errors.add("presentations", ValidationError::new("multiple_not_allowed"));
-                }
-            } else {
-                errors.add("presentations", ValidationError::new("unrequested_credential"));
+    if let Some(credential_sets) = &dcql_query.credential_sets {
+        // Check if all required credential sets are satisfied.
+        for credential_set in credential_sets {
+            if credential_set.required.unwrap_or(true) && !is_credential_set_satisfied(presentations, credential_set) {
+                return Err(VpTokenBuilderError::RequiredCredentialSetNotSatisfied(
+                    credential_set.clone(),
+                ));
             }
         }
-
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
+    } else {
+        // If there are no credential sets, we assume all credentials are required.
+        for credential_query in &dcql_query.credentials {
+            if !presentations.contains_key(&credential_query.id) {
+                return Err(VpTokenBuilderError::MissingRequiredCredential(
+                    credential_query.id.clone(),
+                ));
+            }
         }
     }
 
-    /// Check if at least one option in the credential set is fully satisfied
-    fn is_credential_set_satisfied(&self, credential_set: &crate::dcql::dcql_query::CredentialSetQuery) -> bool {
-        credential_set.options.iter().any(|option| {
-            option.iter().all(|credential_id_str| {
-                crate::dcql::dcql_query::CredentialQueryId::try_new(credential_id_str.clone())
-                    .map(|id| self.presentations.contains_key(&id))
-                    .unwrap_or(false)
-            })
-        })
+    // Check multiple constraints and for no unrequested presentations
+    for (credential_id, credential_presentations) in presentations {
+        if let Some(credential_query) = credential_queries.get(credential_id) {
+            if !credential_query.multiple.unwrap_or(false) && credential_presentations.len() > 1 {
+                return Err(VpTokenBuilderError::MultipleNotAllowed(credential_id.clone()));
+            }
+        } else {
+            return Err(VpTokenBuilderError::UnrequestedCredential(credential_id.clone()));
+        }
     }
+
+    Ok(())
+}
+
+/// Check if at least one option in the credential set is fully satisfied
+fn is_credential_set_satisfied(
+    presentations: &HashMap<CredentialQueryId, Presentations>,
+    credential_set: &crate::dcql::dcql_query::CredentialSetQuery,
+) -> bool {
+    credential_set.options.iter().any(|option| {
+        option
+            .iter()
+            .all(|credential_query_id| presentations.contains_key(credential_query_id))
+    })
 }
 
 #[cfg(test)]
@@ -110,8 +117,8 @@ mod tests {
     use crate::dcql::dcql_query::CredentialQueryId;
     use serde_json::json;
 
-    fn dummy_presentation() -> PresentationFormat {
-        PresentationFormat::JwtVcJson("dummy.jwt.token".to_string())
+    fn dummy_presentation() -> String {
+        "dummy.jwt.token".to_string()
     }
 
     #[test]
@@ -133,15 +140,21 @@ mod tests {
 
         // Test: Add presentation for credential that wasn't requested
         let result = VpTokenBuilder::builder_dcql_query(dcql_query)
-            .add_presentation(
+            .add_presentations(
+                CredentialQueryId::try_new("requested-cred".to_string()).unwrap(),
+                Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
+            )
+            .add_presentations(
                 CredentialQueryId::try_new("unrequested-cred".to_string()).unwrap(),
-                dummy_presentation(),
+                Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .build();
 
         assert!(result.is_err());
-        let error_string = result.unwrap_err().to_string();
-        assert!(error_string.contains("unrequested_credential"));
+        assert!(matches!(
+            result.unwrap_err(),
+            VpTokenBuilderError::UnrequestedCredential(_)
+        ));
     }
 
     #[test]
@@ -182,9 +195,9 @@ mod tests {
 
         // Provide only required credential, skip optional (should pass)
         let result = VpTokenBuilder::builder_dcql_query(dcql_query)
-            .add_presentation(
+            .add_presentations(
                 CredentialQueryId::try_new("mdl-id".to_string()).unwrap(),
-                dummy_presentation(),
+                Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .build();
 
@@ -228,14 +241,14 @@ mod tests {
         let dcql_query: DcqlQuery = serde_json::from_value(dcql_query_json).unwrap();
 
         let result = VpTokenBuilder::builder_dcql_query(dcql_query)
-            .add_presentation(
+            .add_presentations(
                 CredentialQueryId::try_new("mdl-id".to_string()).unwrap(),
-                dummy_presentation(),
+                Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
-            .add_presentation(
+            .add_presentations(
                 // This credential is unrequested and should cause an error
                 CredentialQueryId::try_new("thats-not-right".to_string()).unwrap(),
-                dummy_presentation(),
+                Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .build();
 
@@ -281,13 +294,13 @@ mod tests {
         let dcql_query: DcqlQuery = serde_json::from_value(dcql_query_json).unwrap();
 
         let result = VpTokenBuilder::builder_dcql_query(dcql_query)
-            .add_presentation(
+            .add_presentations(
                 CredentialQueryId::try_new("mdl-id".to_string()).unwrap(),
-                dummy_presentation(),
+                Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
-            .add_presentation(
+            .add_presentations(
                 CredentialQueryId::try_new("optional-cred".to_string()).unwrap(),
-                dummy_presentation(),
+                Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .build();
 
@@ -380,13 +393,13 @@ mod tests {
         let dcql_query: DcqlQuery = serde_json::from_value(dcql_query_json).unwrap();
 
         let result = VpTokenBuilder::builder_dcql_query(dcql_query)
-            .add_presentation(
+            .add_presentations(
                 CredentialQueryId::try_new("unrequested-cred".to_string()).unwrap(),
-                dummy_presentation(),
+                Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
-            .add_presentation(
+            .add_presentations(
                 CredentialQueryId::try_new("optional-cred".to_string()).unwrap(),
-                dummy_presentation(),
+                Presentations::try_new(vec![dummy_presentation().into()]).unwrap(),
             )
             .build();
 

--- a/oid4vp/src/token/vp_token_validator.rs
+++ b/oid4vp/src/token/vp_token_validator.rs
@@ -59,6 +59,8 @@ pub enum VpTokenValidationError {
         expected: Option<String>,
         found: Option<String>,
     },
+    #[error("Missing holder binding")]
+    MissingHolderBinding,
     #[error("Missing custom claims in presentation")]
     MissingCustomClaims,
     #[error("Decoded credentials should not be empty")]
@@ -127,20 +129,27 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
                 .find(|credential_query| credential_query.id == *credential_query_id)
                 .ok_or_else(|| VpTokenValidationError::CredentialQueryNotFound(credential_query_id.clone()))?;
 
+            let require_holder_binding = credential_query.require_cryptographic_holder_binding.unwrap_or(true);
+
             // Decode and validate signatures based on format
             let current_query_decoded_credentials = match credential_query.format {
                 Format::JwtVcJson => {
                     self.validate_jwt_vc_json_presentations(
                         presentations.as_slice(),
-                        credential_query,
                         client_id,
                         nonce,
+                        require_holder_binding,
                     )
                     .await?
                 }
                 Format::DcSdJwt => {
-                    self.validate_dc_sd_jwt_presentations(presentations.as_slice(), client_id, nonce)
-                        .await?
+                    self.validate_dc_sd_jwt_presentations(
+                        presentations.as_slice(),
+                        client_id,
+                        nonce,
+                        require_holder_binding,
+                    )
+                    .await?
                 }
                 Format::VcSdJwt => {
                     self.validate_vc_sd_jwt_presentations(presentations.as_slice(), credential_query, client_id, nonce)
@@ -168,9 +177,9 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
     async fn validate_jwt_vc_json_presentations(
         &self,
         presentations: &[StringOrObject],
-        credential_query: &CredentialQuery,
         client_id: &str,
         nonce: Option<&str>,
+        require_holder_binding: bool,
     ) -> Result<Vec<JsonObject>, VpTokenValidationError> {
         let mut decoded_credentials = vec![];
         // TODO: check `multiple`
@@ -183,7 +192,7 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
             // If holder binding is required, we validate the presentation JWT itself (which proves possession).
             // Otherwise, we treat the input directly as a credential JWT (if that's the model, though typically
             // VP-Token implies a presentation wrapper).
-            let credential_jwts = if credential_query.require_cryptographic_holder_binding.unwrap_or(true) {
+            let credential_jwts = if require_holder_binding {
                 let decoded_jwt_presentation: DecodedJwtPresentation<Jwt> =
                     self.validate_presentation_jwt(&jwt, client_id, nonce).await?;
 
@@ -211,6 +220,7 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
         presentations: &[StringOrObject],
         client_id: &str,
         nonce: Option<&str>,
+        require_holder_binding: bool,
     ) -> Result<Vec<JsonObject>, VpTokenValidationError> {
         let mut decoded_credentials = vec![];
         // TODO: check `multiple`
@@ -221,7 +231,9 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
             let sd_jwt_vc = SdJwtVc::parse(presentation_str)
                 .map_err(|e| VpTokenValidationError::SdJwtParsingError(e.to_string()))?;
 
-            let decoded_sd_jwt_vc = self.validate_sd_jwt_vc(&sd_jwt_vc, client_id, nonce).await?;
+            let decoded_sd_jwt_vc = self
+                .validate_sd_jwt_vc(&sd_jwt_vc, client_id, nonce, require_holder_binding)
+                .await?;
 
             let obj = serde_json::to_value(decoded_sd_jwt_vc)?
                 .as_object()
@@ -272,7 +284,7 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
             };
 
             for sd_jwt in sd_jwts {
-                let decoded_vc_sd_jwt = self.validate_vcdm2_sd_jwt(&sd_jwt, client_id, nonce).await?;
+                let decoded_vc_sd_jwt = self.validate_vcdm2_sd_jwt(&sd_jwt).await?;
 
                 let obj = serde_json::to_value(decoded_vc_sd_jwt)?
                     .as_object()
@@ -385,6 +397,7 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
         sd_jwt_vc: &SdJwtVc,
         client_id: &str,
         nonce: Option<&str>,
+        require_holder_binding: bool,
     ) -> Result<JsonObject, VpTokenValidationError> {
         let kid_str = sd_jwt_vc
             .headers()
@@ -415,22 +428,26 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
             .verify_signature(&self.signature_verifier, &public_key_jwk)
             .map_err(|e| VpTokenValidationError::SdJwtValidation(e.to_string()))?;
 
-        // 2. Verify Key Binding (Holder Binding)
-        if let Some(key_binding_jwt) = sd_jwt_vc.key_binding_jwt() {
-            if key_binding_jwt.claims().aud != client_id {
-                return Err(VpTokenValidationError::InvalidAudience {
-                    expected: Some(client_id.to_string()),
-                    found: Some(key_binding_jwt.claims().aud.clone()),
-                });
-            }
-
-            if let Some(nonce) = nonce {
-                if key_binding_jwt.claims().nonce != nonce {
-                    return Err(VpTokenValidationError::InvalidNonce {
-                        expected: Some(nonce.to_string()),
-                        found: Some(key_binding_jwt.claims().nonce.clone()),
+        // 2. Verify Key Binding (Holder Binding) if required
+        if require_holder_binding {
+            if let Some(key_binding_jwt) = sd_jwt_vc.key_binding_jwt() {
+                if key_binding_jwt.claims().aud != client_id {
+                    return Err(VpTokenValidationError::InvalidAudience {
+                        expected: Some(client_id.to_string()),
+                        found: Some(key_binding_jwt.claims().aud.clone()),
                     });
                 }
+
+                if let Some(nonce) = nonce {
+                    if key_binding_jwt.claims().nonce != nonce {
+                        return Err(VpTokenValidationError::InvalidNonce {
+                            expected: Some(nonce.to_string()),
+                            found: Some(key_binding_jwt.claims().nonce.clone()),
+                        });
+                    }
+                }
+            } else {
+                return Err(VpTokenValidationError::MissingHolderBinding);
             }
         }
 
@@ -441,12 +458,7 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
     }
 
     /// Internal helper to validate VCDM 2.0 SD-JWT.
-    async fn validate_vcdm2_sd_jwt(
-        &self,
-        vcdm2_sd_jwt: &SdJwt,
-        _client_id: &str,
-        _nonce: Option<&str>,
-    ) -> Result<CredentialV2, VpTokenValidationError> {
+    async fn validate_vcdm2_sd_jwt(&self, vcdm2_sd_jwt: &SdJwt) -> Result<CredentialV2, VpTokenValidationError> {
         let kid_str = vcdm2_sd_jwt
             .headers()
             .get("kid")
@@ -517,6 +529,7 @@ impl DecodedVpTokenBuilder {
     }
 }
 
+// TODO: We need to add credential signing functionality to `VpTokenBuilder` in order to have more thorough tests for the validator. For now, we are using pre-generated JWTs and SD-JWTs.
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/oid4vp/src/token/vp_token_validator.rs
+++ b/oid4vp/src/token/vp_token_validator.rs
@@ -78,18 +78,18 @@ pub enum VpTokenValidationError {
 }
 
 /// A type validating [`VpToken`]s.
-pub struct VpTokenValidator<V: JwsVerifier, VMR: VerificationMaterialResolver> {
+pub struct VpTokenValidator<'a, V: JwsVerifier, VMR: VerificationMaterialResolver> {
     jwt_presentation_validator: JwtPresentationValidator<V>,
     jwt_credential_validator: JwtCredentialValidator<V>,
     sd_jwt_credential_validator: SdJwtCredentialValidator<V>,
-    signature_verifier: V,
-    verification_material_resolver: VMR,
+    signature_verifier: &'a V,
+    verification_material_resolver: &'a VMR,
 }
 
-impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidator<SV, VMR> {
+impl<'a, SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidator<'a, SV, VMR> {
     /// Create a new [`VpTokenValidator`] that delegates cryptographic signature verification to
     /// `signature_verifier` and resolves DIDs using `verification_material_resolver`
-    pub fn new(signature_verifier: SV, verification_material_resolver: VMR) -> Self {
+    pub fn new(signature_verifier: &'a SV, verification_material_resolver: &'a VMR) -> Self {
         Self {
             jwt_presentation_validator: JwtPresentationValidator::with_signature_verifier(signature_verifier.clone()),
             jwt_credential_validator: JwtCredentialValidator::with_signature_verifier(signature_verifier.clone()),
@@ -425,7 +425,7 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
 
         // 1. Verify Issuer Signature
         sd_jwt_vc
-            .verify_signature(&self.signature_verifier, &public_key_jwk)
+            .verify_signature(self.signature_verifier, &public_key_jwk)
             .map_err(|e| VpTokenValidationError::SdJwtValidation(e.to_string()))?;
 
         // 2. Verify Key Binding (Holder Binding) if required
@@ -582,7 +582,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+            VpTokenValidator::new(&SignatureVerifier, &TestVerificationMaterialResolver)
                 .validate_vp_token(
                     &dcql_query,
                     &vp_token,
@@ -625,7 +625,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+            VpTokenValidator::new(&SignatureVerifier, &TestVerificationMaterialResolver)
                 .validate_vp_token(
                     &dcql_query,
                     &vp_token,
@@ -672,7 +672,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+            VpTokenValidator::new(&SignatureVerifier, &TestVerificationMaterialResolver)
                 .validate_vp_token(
                     &dcql_query,
                     &vp_token,
@@ -720,7 +720,7 @@ mod tests {
             .unwrap();
 
         assert!(matches!(
-            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+            VpTokenValidator::new(&SignatureVerifier, &TestVerificationMaterialResolver)
                 .validate_vp_token(
                     &dcql_query,
                     &vp_token,
@@ -769,7 +769,7 @@ mod tests {
             .unwrap();
 
         assert!(matches!(
-            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+            VpTokenValidator::new(&SignatureVerifier, &TestVerificationMaterialResolver)
                 .validate_vp_token(
                     &dcql_query,
                     &vp_token,
@@ -825,7 +825,7 @@ mod tests {
             .unwrap();
 
         assert!(matches!(
-            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+            VpTokenValidator::new(&SignatureVerifier, &TestVerificationMaterialResolver)
                 .validate_vp_token(
                     &dcql_query,
                     &vp_token,
@@ -876,7 +876,7 @@ mod tests {
             .unwrap();
 
         assert!(matches!(
-            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+            VpTokenValidator::new(&SignatureVerifier, &TestVerificationMaterialResolver)
                 .validate_vp_token(
                     &dcql_query,
                     &vp_token,
@@ -929,7 +929,7 @@ mod tests {
             .unwrap();
 
         assert!(matches!(
-            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+            VpTokenValidator::new(&SignatureVerifier, &TestVerificationMaterialResolver)
                 .validate_vp_token(
                     &dcql_query,
                     &vp_token,

--- a/oid4vp/src/token/vp_token_validator.rs
+++ b/oid4vp/src/token/vp_token_validator.rs
@@ -100,12 +100,12 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
     /// Validate the provided [`VpToken`] against the given [`DcqlQuery`].
     ///
     /// This process involves:
-    /// 1. Iterating through presentations in the `vp_token`.
-    /// 2. Matching each presentation to a `CredentialQuery` in the `dcql_query`.
-    /// 3. Validating the format-specific structure and signatures of each presentation.
-    /// 4. Decoding the credentials into a common format (`JsonObject`).
-    /// 5. Evaluating the decoded credentials against the full logic of the `dcql_query` (including sets and claims).
-    /// 6. Validating the structural submission of the presentations (e.g. required sets satisfied).
+    /// 1. Validating the structural submission of the presentations (e.g. required sets satisfied).
+    /// 2. Iterating through presentations in the `vp_token`.
+    /// 3. Matching each presentation to a `CredentialQuery` in the `dcql_query`.
+    /// 4. Validating the format-specific structure and signatures of each presentation.
+    /// 5. Decoding the credentials into a common format (`JsonObject`).
+    /// 6. Evaluating the decoded credentials against the full logic of the `dcql_query` (including sets and claims).
     pub async fn validate_vp_token(
         &self,
         dcql_query: &DcqlQuery,
@@ -113,6 +113,10 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
         client_id: &str,
         nonce: Option<&str>,
     ) -> Result<DecodedVpToken, VpTokenValidationError> {
+        // Validate that the structural requirements (e.g. required groups) of the DCQL query are met
+        validate_presentation_submission(&vp_token.presentations, dcql_query)
+            .map_err(VpTokenValidationError::PresentationSubmissionValidation)?;
+
         let mut builder = DecodedVpTokenBuilder::new();
 
         for (credential_query_id, presentations) in vp_token.presentations.iter() {
@@ -154,10 +158,6 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
         if !evaluate_dcql_query(dcql_query, &decoded_vp_token) {
             return Err(VpTokenValidationError::DcqlEvaluationFailed);
         }
-
-        // Validate that the structural requirements (e.g. required groups) of the DCQL query are met
-        validate_presentation_submission(&vp_token.presentations, dcql_query)
-            .map_err(VpTokenValidationError::PresentationSubmissionValidation)?;
 
         Ok(decoded_vp_token)
     }
@@ -319,11 +319,6 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
             .jwt_presentation_validator
             .validate(presentation_jwt, &holder, options)?;
 
-        let custom_claims = decoded_jwt_presentation
-            .custom_claims
-            .as_ref()
-            .ok_or(VpTokenValidationError::MissingCustomClaims)?;
-
         // 4. Check Audience
         let aud = decoded_jwt_presentation.aud.as_ref().map(|aud| aud.to_string());
 
@@ -334,13 +329,20 @@ impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidato
             });
         }
 
-        // 5. Check Nonce
-        let jwt_nonce = custom_claims.get("nonce").and_then(|v| v.as_str());
-        if jwt_nonce != nonce {
-            return Err(VpTokenValidationError::InvalidNonce {
-                expected: nonce.map(String::from),
-                found: jwt_nonce.map(String::from),
-            });
+        // 5. Check Nonce (if provided)
+        if nonce.is_some() {
+            let custom_claims = decoded_jwt_presentation
+                .custom_claims
+                .as_ref()
+                .ok_or(VpTokenValidationError::MissingCustomClaims)?;
+
+            let jwt_nonce = custom_claims.get("nonce").and_then(|v| v.as_str());
+            if jwt_nonce != nonce {
+                return Err(VpTokenValidationError::InvalidNonce {
+                    expected: nonce.map(String::from),
+                    found: jwt_nonce.map(String::from),
+                });
+            }
         }
 
         Ok(decoded_jwt_presentation)
@@ -822,7 +824,7 @@ mod tests {
             // The JWT VC JSON credential is valid and the nonce matches, but the DCQL query is looking for a VC SD-JWT
             // credential, so the validation should fail with a PresentationValidation error indicating that the
             // credential format does not match the expected format.
-            VpTokenValidationError::PresentationValidation { .. }
+            VpTokenValidationError::PresentationValidation(_)
         ));
     }
 
@@ -878,7 +880,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn credential_query_id_mismatch_results_in_not_found_error() {
+    async fn credential_query_id_mismatch_results_in_presentation_submission_validation_error() {
         let dcql_query = DcqlQuery {
             credentials: vec![CredentialQuery {
                 id: CredentialQueryId::try_new("CredentialQuery").unwrap(),
@@ -925,9 +927,9 @@ mod tests {
                 .unwrap_err(),
             // The JWT VC JSON credential is valid, the nonce matches, and the client ID matches, but the VP token
             // contains a presentation for a Credential Query with a different ID than the one in the DCQL query, so
-            // the validation should fail with a CredentialQueryNotFound error indicating that there is no
+            // the validation should fail with a MissingRequiredCredential error indicating that there is no
             // presentation in the VP token for the Credential Query in the DCQL query.
-            VpTokenValidationError::CredentialQueryNotFound { .. }
+            VpTokenValidationError::PresentationSubmissionValidation(VpTokenBuilderError::MissingRequiredCredential(_))
         ));
     }
 }

--- a/oid4vp/src/token/vp_token_validator.rs
+++ b/oid4vp/src/token/vp_token_validator.rs
@@ -1,0 +1,933 @@
+use crate::{
+    dcql::dcql_query::{CredentialQuery, CredentialQueryId, DcqlQuery, Format},
+    dcql_evaluation::evaluate_dcql_query,
+    token::vp_token_builder::{validate_presentation_submission, VpTokenBuilderError},
+    VpToken,
+};
+use getset::Getters;
+use identity_credential::{
+    credential::{CredentialV2, EnvelopedVc, Jwt},
+    sd_jwt_payload::{SdJwt, Sha256Hasher},
+    sd_jwt_vc::SdJwtVc,
+    validator::{
+        DecodedJwtCredential, DecodedJwtPresentation, FailFast, JwtCredentialValidationOptions, JwtCredentialValidator,
+        JwtPresentationValidator, SdJwtCredentialValidator, StatusCheck,
+    },
+};
+use identity_did::DIDUrl;
+use identity_verification::jws::{Decoder, JwsVerifier};
+use nutype::nutype;
+use oid4vc_core::utils::predicates::not_empty;
+use oid4vc_core::{
+    types::string_or_object::StringOrObject, verification_material_resolver::VerificationMaterialResolver, JsonObject,
+};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::collections::HashMap;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum VpTokenValidationError {
+    #[error("Credential query with id `{0}` not found in DCQL query")]
+    CredentialQueryNotFound(CredentialQueryId),
+    #[error("Invalid presentation format: expected string")]
+    InvalidPresentationFormat,
+    #[error("JWS decoding error: {0}")]
+    JwsDecodingError(#[from] identity_jose::error::Error),
+    #[error("Invalid KID: {0}")]
+    InvalidKid(String),
+    #[error("Verification material resolution error: {0}")]
+    VerificationMaterialResolutionError(String),
+    #[error("JWT validation error: {0}")]
+    JwtValidation(#[from] identity_credential::validator::JwtValidationError),
+    #[error("Credential validation error: {0}")]
+    CredentialValidation(#[from] identity_credential::validator::CompoundCredentialValidationError),
+    #[error("Presentation validation error: {0}")]
+    PresentationValidation(#[from] identity_credential::validator::CompoundJwtPresentationValidationError),
+    #[error("Serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
+    #[error("SD-JWT parsing error: {0}")]
+    SdJwtParsingError(String),
+    #[error("SD-JWT validation error: {0}")]
+    SdJwtValidation(String),
+    #[error("Invalid audience: expected {expected:?}, found {found:?}")]
+    InvalidAudience {
+        expected: Option<String>,
+        found: Option<String>,
+    },
+    #[error("Invalid nonce: expected {expected:?}, found {found:?}")]
+    InvalidNonce {
+        expected: Option<String>,
+        found: Option<String>,
+    },
+    #[error("Missing custom claims in presentation")]
+    MissingCustomClaims,
+    #[error("Decoded credentials should not be empty")]
+    EmptyDecodedCredentials,
+    #[error("Unsupported credential format")]
+    UnsupportedFormat,
+    #[error("Decoded credential is not a JSON object")]
+    InvalidDecodedCredentialType,
+    #[error("Missing KID in header")]
+    MissingKid,
+    #[error("DCQL evaluation failed")]
+    DcqlEvaluationFailed,
+    #[error("Presentation submission validation failed: {0}")]
+    PresentationSubmissionValidation(#[from] VpTokenBuilderError),
+}
+
+/// A type validating [`VpToken`]s.
+pub struct VpTokenValidator<V: JwsVerifier, VMR: VerificationMaterialResolver> {
+    jwt_presentation_validator: JwtPresentationValidator<V>,
+    jwt_credential_validator: JwtCredentialValidator<V>,
+    sd_jwt_credential_validator: SdJwtCredentialValidator<V>,
+    signature_verifier: V,
+    verification_material_resolver: VMR,
+}
+
+impl<SV: JwsVerifier + Clone, VMR: VerificationMaterialResolver> VpTokenValidator<SV, VMR> {
+    /// Create a new [`VpTokenValidator`] that delegates cryptographic signature verification to
+    /// `signature_verifier` and resolves DIDs using `verification_material_resolver`
+    pub fn new(signature_verifier: SV, verification_material_resolver: VMR) -> Self {
+        Self {
+            jwt_presentation_validator: JwtPresentationValidator::with_signature_verifier(signature_verifier.clone()),
+            jwt_credential_validator: JwtCredentialValidator::with_signature_verifier(signature_verifier.clone()),
+            sd_jwt_credential_validator: SdJwtCredentialValidator::new(signature_verifier.clone(), Sha256Hasher),
+            signature_verifier,
+            verification_material_resolver,
+        }
+    }
+
+    /// Validate the provided [`VpToken`] against the given [`DcqlQuery`].
+    ///
+    /// This process involves:
+    /// 1. Iterating through presentations in the `vp_token`.
+    /// 2. Matching each presentation to a `CredentialQuery` in the `dcql_query`.
+    /// 3. Validating the format-specific structure and signatures of each presentation.
+    /// 4. Decoding the credentials into a common format (`JsonObject`).
+    /// 5. Evaluating the decoded credentials against the full logic of the `dcql_query` (including sets and claims).
+    /// 6. Validating the structural submission of the presentations (e.g. required sets satisfied).
+    pub async fn validate_vp_token(
+        &self,
+        dcql_query: &DcqlQuery,
+        vp_token: &VpToken,
+        client_id: &str,
+        nonce: Option<&str>,
+    ) -> Result<DecodedVpToken, VpTokenValidationError> {
+        let mut builder = DecodedVpTokenBuilder::new();
+
+        for (credential_query_id, presentations) in vp_token.presentations.iter() {
+            // Find the corresponding query definition for this presentation ID
+            let credential_query = dcql_query
+                .credentials
+                .iter()
+                .find(|credential_query| credential_query.id == *credential_query_id)
+                .ok_or_else(|| VpTokenValidationError::CredentialQueryNotFound(credential_query_id.clone()))?;
+
+            // Decode and validate signatures based on format
+            let current_query_decoded_credentials = match credential_query.format {
+                Format::JwtVcJson => {
+                    self.validate_jwt_vc_json_presentations(
+                        presentations.as_slice(),
+                        credential_query,
+                        client_id,
+                        nonce,
+                    )
+                    .await?
+                }
+                Format::DcSdJwt => {
+                    self.validate_dc_sd_jwt_presentations(presentations.as_slice(), client_id, nonce)
+                        .await?
+                }
+                Format::VcSdJwt => {
+                    self.validate_vc_sd_jwt_presentations(presentations.as_slice(), credential_query, client_id, nonce)
+                        .await?
+                }
+                _ => return Err(VpTokenValidationError::UnsupportedFormat),
+            };
+
+            builder = builder.insert(credential_query_id.clone(), current_query_decoded_credentials)?;
+        }
+
+        let decoded_vp_token = builder.build();
+
+        // Perform semantic validation of the claims requested in the DCQL query
+        if !evaluate_dcql_query(dcql_query, &decoded_vp_token) {
+            return Err(VpTokenValidationError::DcqlEvaluationFailed);
+        }
+
+        // Validate that the structural requirements (e.g. required groups) of the DCQL query are met
+        validate_presentation_submission(&vp_token.presentations, dcql_query)
+            .map_err(VpTokenValidationError::PresentationSubmissionValidation)?;
+
+        Ok(decoded_vp_token)
+    }
+
+    /// Validates a list of presentations in `jwt_vc_json` format.
+    /// For each presentation, it verifies the signature and structural validity,
+    /// then extracts the internal credential.
+    async fn validate_jwt_vc_json_presentations(
+        &self,
+        presentations: &[StringOrObject],
+        credential_query: &CredentialQuery,
+        client_id: &str,
+        nonce: Option<&str>,
+    ) -> Result<Vec<JsonObject>, VpTokenValidationError> {
+        let mut decoded_credentials = vec![];
+        // TODO: check `multiple`
+        for presentation in presentations.iter() {
+            let presentation_str = presentation
+                .as_str()
+                .ok_or(VpTokenValidationError::InvalidPresentationFormat)?;
+            let jwt = Jwt::new(presentation_str.to_string());
+
+            // If holder binding is required, we validate the presentation JWT itself (which proves possession).
+            // Otherwise, we treat the input directly as a credential JWT (if that's the model, though typically
+            // VP-Token implies a presentation wrapper).
+            let credential_jwts = if credential_query.require_cryptographic_holder_binding.unwrap_or(true) {
+                let decoded_jwt_presentation: DecodedJwtPresentation<Jwt> =
+                    self.validate_presentation_jwt(&jwt, client_id, nonce).await?;
+
+                decoded_jwt_presentation.presentation.verifiable_credential
+            } else {
+                vec![jwt]
+            };
+
+            for credential_jwt in credential_jwts {
+                let decoded_credential = self.validate_credential_jwt(&credential_jwt).await?;
+
+                let obj = serde_json::to_value(decoded_credential.credential)?
+                    .as_object()
+                    .cloned()
+                    .ok_or(VpTokenValidationError::InvalidDecodedCredentialType)?;
+                decoded_credentials.push(obj);
+            }
+        }
+        Ok(decoded_credentials)
+    }
+
+    /// Validates a list of presentations in `dc+sd-jwt` format.
+    async fn validate_dc_sd_jwt_presentations(
+        &self,
+        presentations: &[StringOrObject],
+        client_id: &str,
+        nonce: Option<&str>,
+    ) -> Result<Vec<JsonObject>, VpTokenValidationError> {
+        let mut decoded_credentials = vec![];
+        // TODO: check `multiple`
+        for presentation in presentations.iter() {
+            let presentation_str = presentation
+                .as_str()
+                .ok_or(VpTokenValidationError::InvalidPresentationFormat)?;
+            let sd_jwt_vc = SdJwtVc::parse(presentation_str)
+                .map_err(|e| VpTokenValidationError::SdJwtParsingError(e.to_string()))?;
+
+            let decoded_sd_jwt_vc = self.validate_sd_jwt_vc(&sd_jwt_vc, client_id, nonce).await?;
+
+            let obj = serde_json::to_value(decoded_sd_jwt_vc)?
+                .as_object()
+                .cloned()
+                .ok_or(VpTokenValidationError::InvalidDecodedCredentialType)?;
+            decoded_credentials.push(obj);
+        }
+        Ok(decoded_credentials)
+    }
+
+    /// Validates a list of presentations in `vc+sd-jwt` format.
+    async fn validate_vc_sd_jwt_presentations(
+        &self,
+        presentations: &[StringOrObject],
+        credential_query: &CredentialQuery,
+        client_id: &str,
+        nonce: Option<&str>,
+    ) -> Result<Vec<JsonObject>, VpTokenValidationError> {
+        let mut decoded_credentials = vec![];
+        // TODO: check `multiple`
+        for presentation in presentations.iter() {
+            let presentation_str = presentation
+                .as_str()
+                .ok_or(VpTokenValidationError::InvalidPresentationFormat)?;
+            let jwt = Jwt::new(presentation_str.to_string());
+
+            // Similar logic to standard JWTs: verify holder binding if required by extracting SD-JWTs
+            // from the validated presentation wrapper.
+            let sd_jwts: Vec<SdJwt> = if credential_query.require_cryptographic_holder_binding.unwrap_or(true) {
+                let decoded_jwt_presentation: DecodedJwtPresentation<EnvelopedVc> =
+                    self.validate_presentation_jwt(&jwt, client_id, nonce).await?;
+
+                decoded_jwt_presentation
+                    .presentation
+                    .verifiable_credential
+                    .iter()
+                    .map(|cred| {
+                        SdJwt::parse(cred.id.encoded_data())
+                            .map_err(|e| VpTokenValidationError::SdJwtParsingError(e.to_string()))
+                    })
+                    .collect::<Result<_, _>>()?
+            } else {
+                vec![presentation_str
+                    .parse()
+                    .map_err(|e: identity_credential::sd_jwt_payload::Error| {
+                        VpTokenValidationError::SdJwtParsingError(e.to_string())
+                    })?]
+            };
+
+            for sd_jwt in sd_jwts {
+                let decoded_vc_sd_jwt = self.validate_vcdm2_sd_jwt(&sd_jwt, client_id, nonce).await?;
+
+                let obj = serde_json::to_value(decoded_vc_sd_jwt)?
+                    .as_object()
+                    .cloned()
+                    .ok_or(VpTokenValidationError::InvalidDecodedCredentialType)?;
+                decoded_credentials.push(obj);
+            }
+        }
+        Ok(decoded_credentials)
+    }
+
+    /// Internal helper to validate a generic JWT presentation (signature, audience, nonce).
+    async fn validate_presentation_jwt<CRED>(
+        &self,
+        presentation_jwt: &Jwt,
+        client_id: &str,
+        nonce: Option<&str>,
+    ) -> Result<DecodedJwtPresentation<CRED>, VpTokenValidationError>
+    where
+        CRED: Serialize + DeserializeOwned + Clone,
+    {
+        // 1. Decode header to find KID
+        let validation_item = Decoder::new()
+            .decode_compact_serialization(presentation_jwt.as_str().as_bytes(), None)
+            .map_err(VpTokenValidationError::JwsDecodingError)?;
+
+        let kid_str = validation_item.kid().ok_or(VpTokenValidationError::MissingKid)?;
+        let kid: DIDUrl = kid_str
+            .parse()
+            .map_err(|e: identity_did::Error| VpTokenValidationError::InvalidKid(e.to_string()))?;
+
+        // 2. Resolve Holder's DID Document
+        let resolver = &self.verification_material_resolver;
+
+        let holder = resolver
+            .resolve_did_document(kid.did())
+            .await
+            .map_err(|e| VpTokenValidationError::VerificationMaterialResolutionError(e.to_string()))?;
+
+        // 3. Verify Signature
+        let options = &Default::default();
+
+        let decoded_jwt_presentation = self
+            .jwt_presentation_validator
+            .validate(presentation_jwt, &holder, options)?;
+
+        let custom_claims = decoded_jwt_presentation
+            .custom_claims
+            .as_ref()
+            .ok_or(VpTokenValidationError::MissingCustomClaims)?;
+
+        // 4. Check Audience
+        let aud = decoded_jwt_presentation.aud.as_ref().map(|aud| aud.to_string());
+
+        if aud != Some(client_id.to_string()) {
+            return Err(VpTokenValidationError::InvalidAudience {
+                expected: Some(client_id.to_string()),
+                found: aud,
+            });
+        }
+
+        // 5. Check Nonce
+        let jwt_nonce = custom_claims.get("nonce").and_then(|v| v.as_str());
+        if jwt_nonce != nonce {
+            return Err(VpTokenValidationError::InvalidNonce {
+                expected: nonce.map(String::from),
+                found: jwt_nonce.map(String::from),
+            });
+        }
+
+        Ok(decoded_jwt_presentation)
+    }
+
+    /// Internal helper to validate a credential JWT.
+    async fn validate_credential_jwt(
+        &self,
+        credential_jwt: &Jwt,
+    ) -> Result<DecodedJwtCredential<JsonObject>, VpTokenValidationError> {
+        let validation_item = Decoder::new()
+            .decode_compact_serialization(credential_jwt.as_str().as_bytes(), None)
+            .map_err(VpTokenValidationError::JwsDecodingError)?;
+
+        let kid_str = validation_item.kid().ok_or(VpTokenValidationError::MissingKid)?;
+        let kid: DIDUrl = kid_str
+            .parse()
+            .map_err(|e: identity_did::Error| VpTokenValidationError::InvalidKid(e.to_string()))?;
+
+        let resolver = &self.verification_material_resolver;
+
+        // TODO: verify whether issuer is trusted (through `trusted_authorities`).
+        let issuer = resolver
+            .resolve_did_document(kid.did())
+            .await
+            .map_err(|e| VpTokenValidationError::VerificationMaterialResolutionError(e.to_string()))?;
+
+        // `SkipUnsupported` allows for custom credential types, such as the StatusList2021Entry (https://www.w3.org/TR/2023/WD-vc-status-list-20230427/#statuslist2021entry)
+        let options = &JwtCredentialValidationOptions::new().status_check(StatusCheck::SkipUnsupported);
+        let fail_fast = FailFast::FirstError;
+
+        self.jwt_credential_validator
+            .validate(credential_jwt, &issuer, options, fail_fast)
+            .map_err(VpTokenValidationError::CredentialValidation)
+    }
+
+    /// Internal helper to validate a generic SD-JWT VC (signature, key binding, disclosures).
+    async fn validate_sd_jwt_vc(
+        &self,
+        sd_jwt_vc: &SdJwtVc,
+        client_id: &str,
+        nonce: Option<&str>,
+    ) -> Result<JsonObject, VpTokenValidationError> {
+        let kid_str = sd_jwt_vc
+            .headers()
+            .get("kid")
+            .ok_or(VpTokenValidationError::MissingKid)?
+            .as_str()
+            .ok_or_else(|| VpTokenValidationError::InvalidKid("kid header is not a string".to_string()))?;
+
+        let kid: DIDUrl = kid_str
+            .parse()
+            .map_err(|e: identity_did::Error| VpTokenValidationError::InvalidKid(e.to_string()))?;
+
+        let resolver = &self.verification_material_resolver;
+
+        // TODO: verify whether issuer is trusted (through `trusted_authorities`).
+        let _issuer = resolver
+            .resolve_did_document(kid.did())
+            .await
+            .map_err(|e| VpTokenValidationError::VerificationMaterialResolutionError(e.to_string()))?;
+
+        let public_key_jwk = resolver
+            .resolve_public_key(&kid.to_string())
+            .await
+            .map_err(|e| VpTokenValidationError::VerificationMaterialResolutionError(e.to_string()))?;
+
+        // 1. Verify Issuer Signature
+        sd_jwt_vc
+            .verify_signature(&self.signature_verifier, &public_key_jwk)
+            .map_err(|e| VpTokenValidationError::SdJwtValidation(e.to_string()))?;
+
+        // 2. Verify Key Binding (Holder Binding)
+        if let Some(key_binding_jwt) = sd_jwt_vc.key_binding_jwt() {
+            if key_binding_jwt.claims().aud != client_id {
+                return Err(VpTokenValidationError::InvalidAudience {
+                    expected: Some(client_id.to_string()),
+                    found: Some(key_binding_jwt.claims().aud.clone()),
+                });
+            }
+
+            if let Some(nonce) = nonce {
+                if key_binding_jwt.claims().nonce != nonce {
+                    return Err(VpTokenValidationError::InvalidNonce {
+                        expected: Some(nonce.to_string()),
+                        found: Some(key_binding_jwt.claims().nonce.clone()),
+                    });
+                }
+            }
+        }
+
+        sd_jwt_vc
+            .clone()
+            .into_disclosed_object(&Sha256Hasher)
+            .map_err(|e| VpTokenValidationError::SdJwtValidation(e.to_string()))
+    }
+
+    /// Internal helper to validate VCDM 2.0 SD-JWT.
+    async fn validate_vcdm2_sd_jwt(
+        &self,
+        vcdm2_sd_jwt: &SdJwt,
+        _client_id: &str,
+        _nonce: Option<&str>,
+    ) -> Result<CredentialV2, VpTokenValidationError> {
+        let kid_str = vcdm2_sd_jwt
+            .headers()
+            .get("kid")
+            .ok_or(VpTokenValidationError::MissingKid)?
+            .as_str()
+            .ok_or_else(|| VpTokenValidationError::InvalidKid("kid header is not a string".to_string()))?;
+
+        let kid: DIDUrl = kid_str
+            .parse()
+            .map_err(|e: identity_did::Error| VpTokenValidationError::InvalidKid(e.to_string()))?;
+
+        let resolver = &self.verification_material_resolver;
+
+        // TODO: verify whether issuer is trusted (through `trusted_authorities`).
+        let issuer = resolver
+            .resolve_did_document(kid.did())
+            .await
+            .map_err(|e| VpTokenValidationError::VerificationMaterialResolutionError(e.to_string()))?;
+
+        // `SkipUnsupported` allows for custom credential types, such as the StatusList2021Entry (https://www.w3.org/TR/2023/WD-vc-status-list-20230427/#statuslist2021entry)
+        let options = &JwtCredentialValidationOptions::new().status_check(StatusCheck::SkipUnsupported);
+
+        self.sd_jwt_credential_validator
+            .validate_credential_v2(vcdm2_sd_jwt, &[issuer], options)
+            .map_err(|e| VpTokenValidationError::SdJwtValidation(e.to_string()))
+    }
+}
+
+#[derive(Serialize, Clone, Deserialize, Debug, Getters, PartialEq)]
+pub struct DecodedVpToken {
+    #[serde(flatten)]
+    #[getset(get = "pub")]
+    decoded_presentations: HashMap<CredentialQueryId, DecodedPresentations>,
+}
+
+#[nutype(
+    validate(predicate = not_empty),
+    derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Deref)
+)]
+pub struct DecodedPresentations(Vec<JsonObject>);
+
+#[derive(Default)]
+pub struct DecodedVpTokenBuilder {
+    decoded_presentations: HashMap<CredentialQueryId, DecodedPresentations>,
+}
+
+impl DecodedVpTokenBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(
+        mut self,
+        credential_query_id: CredentialQueryId,
+        decoded_credentials: Vec<JsonObject>,
+    ) -> Result<Self, VpTokenValidationError> {
+        let decoded_presentations = DecodedPresentations::try_new(decoded_credentials)
+            .map_err(|_| VpTokenValidationError::EmptyDecodedCredentials)?;
+        self.decoded_presentations
+            .insert(credential_query_id, decoded_presentations);
+        Ok(self)
+    }
+
+    pub fn build(self) -> DecodedVpToken {
+        DecodedVpToken {
+            decoded_presentations: self.decoded_presentations,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        dcql::dcql_query::{ClaimQuery, CredentialQuery, MetaTypes},
+        token::vp_token::Presentations,
+    };
+    use oid4vc_core::{
+        claim_path_pointer::{ClaimPathElement, ClaimPathPointer},
+        verification_material_resolver::test_utils::TestVerificationMaterialResolver,
+        verifier::SignatureVerifier,
+    };
+
+    const VALID_JWT_VC_JSON_CREDENTIAL: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2g5eTRMU0Y4Mm9Wck03S3pxZjZ1OFVvMU51UFlyUm5kM293QkxFRUFETHBkI3o2TWtoOXk0TFNGODJvVnJNN0t6cWY2dThVbzFOdVBZclJuZDNvd0JMRUVBRExwZCJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtoOXk0TFNGODJvVnJNN0t6cWY2dThVbzFOdVBZclJuZDNvd0JMRUVBRExwZCIsInN1YiI6ImRpZDprZXk6ejZNa2g5eTRMU0Y4Mm9Wck03S3pxZjZ1OFVvMU51UFlyUm5kM293QkxFRUFETHBkIiwiYXVkIjoiZGVjZW50cmFsaXplZF9pZGVudGlmaWVyOmRpZDprZXk6ejZNa2V1cGVQVktpa0x2NEtYRTk5b0F2UWJnQVI3cVhxM0FHVXRzU2VvcVpnRkJWIiwiZXhwIjo3ODIxMjQ3MjUxLCJpYXQiOjE3NzMyNDcyNTEsInZwIjp7IkBjb250ZXh0IjoiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJ0eXBlIjoiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiIsInZlcmlmaWFibGVDcmVkZW50aWFsIjpbImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSkZaRVJUUVNJc0ltdHBaQ0k2SW1ScFpEcHJaWGs2ZWpaTmEyVjFjR1ZRVmt0cGEweDJORXRZUlRrNWIwRjJVV0puUVZJM2NWaHhNMEZIVlhSelUyVnZjVnBuUmtKV0kzbzJUV3RsZFhCbFVGWkxhV3RNZGpSTFdFVTVPVzlCZGxGaVowRlNOM0ZZY1ROQlIxVjBjMU5sYjNGYVowWkNWaUo5LmV5SnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdGxkWEJsVUZaTGFXdE1kalJMV0VVNU9XOUJkbEZpWjBGU04zRlljVE5CUjFWMGMxTmxiM0ZhWjBaQ1ZpSXNJbk4xWWlJNkltUnBaRHByWlhrNmVqWk5hMmc1ZVRSTVUwWTRNbTlXY2swM1MzcHhaaloxT0ZWdk1VNTFVRmx5VW01a00yOTNRa3hGUlVGRVRIQmtJaXdpYm1KbUlqb3hOemN6TWpRM01qSTRMQ0pwWVhRaU9qRTNOek15TkRjeU1qZ3NJblpqSWpwN0ltTnlaV1JsYm5ScFlXeFRkV0pxWldOMElqcDdJbVpwY25OMFgyNWhiV1VpT2lKR1pYSnlhWE1pTENKc1lYTjBYMjVoYldVaU9pSkRjbUZpYldGdUlpd2laRzlpSWpvaU1UazRNaTB3TVMwd01TSXNJbWxrSWpvaVpHbGtPbXRsZVRwNk5rMXJhRGw1TkV4VFJqZ3liMVp5VFRkTGVuRm1OblU0Vlc4eFRuVlFXWEpTYm1RemIzZENURVZGUVVSTWNHUWlmU3dpZEhsd1pTSTZXeUpXWlhKcFptbGhZbXhsUTNKbFpHVnVkR2xoYkNKZExDSnBjM04xWlhJaU9uc2libUZ0WlNJNklsVnVhVU52Y21VaUxDSnBaQ0k2SW1ScFpEcHJaWGs2ZWpaTmEyVjFjR1ZRVmt0cGEweDJORXRZUlRrNWIwRjJVV0puUVZJM2NWaHhNMEZIVlhSelUyVnZjVnBuUmtKV0luMHNJa0JqYjI1MFpYaDBJanBiSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk4eU1ERTRMMk55WldSbGJuUnBZV3h6TDNZeElsMHNJbWx6YzNWaGJtTmxSR0YwWlNJNklqSXdNall0TURNdE1URlVNVFk2TkRBNk1qaGFJaXdpZG1Gc2FXUkdjbTl0SWpvaU1qQXlOaTB3TXkweE1WUXhOam8wTURveU9Gb2lMQ0pqY21Wa1pXNTBhV0ZzVTNSaGRIVnpJanA3SW5SNWNHVWlPaUp6ZEdGMGRYTnNhWE4wSzJwM2RDSXNJbWxrSWpvaWFIUjBjRG92TDJ4dlkyRnNhRzl6ZERvek1ETXpMMmxsZEdZdGIyRjFkR2d0ZEc5clpXNHRjM1JoZEhWekxXeHBjM1F2TVNJc0luVnlhU0k2SW1oMGRIQTZMeTlzYjJOaGJHaHZjM1E2TXpBek15OXBaWFJtTFc5aGRYUm9MWFJ2YTJWdUxYTjBZWFIxY3kxc2FYTjBMekVpTENKcFpIZ2lPamd3TkRoOWZTd2ljM1JoZEhWeklqcDdJbk4wWVhSMWMxOXNhWE4wSWpwN0luVnlhU0k2SW1oMGRIQTZMeTlzYjJOaGJHaHZjM1E2TXpBek15OXBaWFJtTFc5aGRYUm9MWFJ2YTJWdUxYTjBZWFIxY3kxc2FYTjBMekVpTENKcFpIZ2lPamd3TkRoOWZYMC5fS2lDZUVtZmFfVFFXaVNOTk9hWHZfV3FKNkM5ZkNtLVZTUE53NzVNLVBQS1ZYSGtiNlJiM1lGS25DSVo3M1ZGUVBibWVrX0RwV2F5WWVWTm55NjNBZyJdLCJob2xkZXIiOiJkaWQ6a2V5Ono2TWtoOXk0TFNGODJvVnJNN0t6cWY2dThVbzFOdVBZclJuZDNvd0JMRUVBRExwZCJ9LCJub25jZSI6ImJlMWExYjIwMDg0ZjY1NjYwMzNkZTdiYzJmOTBiODM3NzIyZmVhYjRhYjZhZjcxY2VjYjg5ZmY0Mjc0NWFiY2QifQ.59V_DEJ2R75iymoUOC67fN2sWvC_W4KaqeDEvamYjbWe-gTHikTzoyH3zxhjj-YbCWhOibQNeSDf8ELn1lCSAg";
+    const VALID_DC_SD_JWT_CREDENTIAL: &str = "eyJ0eXAiOiJkYytzZC1qd3QiLCJraWQiOiJkaWQ6a2V5Ono2TWtldXBlUFZLaWtMdjRLWEU5OW9BdlFiZ0FSN3FYcTNBR1V0c1Nlb3FaZ0ZCViN6Nk1rZXVwZVBWS2lrTHY0S1hFOTlvQXZRYmdBUjdxWHEzQUdVdHNTZW9xWmdGQlYiLCJhbGciOiJFZERTQSJ9.eyJ2Y3QiOiJodHRwOi8vbG9jYWxob3N0OjMwMzMvdmN0L1UwUXRTbGRVSUZaRC8wIiwiX3NkIjpbIjhWRjlEYkRnaDJrT0kwWW5Cc0dBQUJuTldIZ1puVWlQOENZVjBRMTFmc00iLCJZSUh1ZDNuUHRDV3c1NkY2OWNLYU1NWDNsOGd1UFgwbVNUcDVPSV9QNVo4IiwidWhpSHdOaUtrQUJDN2tBQUxzU0ZMM0JaeXJnb05McnRGTGNXOHg2SWdwMCJdLCJpc3MiOiJkaWQ6a2V5Ono2TWtldXBlUFZLaWtMdjRLWEU5OW9BdlFiZ0FSN3FYcTNBR1V0c1Nlb3FaZ0ZCViIsIm5iZiI6MTc3MzI0NzQxMywiaWF0IjoxNzczMjQ3NDEzLCJzdGF0dXMiOnsic3RhdHVzX2xpc3QiOnsidXJpIjoiaHR0cDovL2xvY2FsaG9zdDozMDMzL2lldGYtb2F1dGgtdG9rZW4tc3RhdHVzLWxpc3QvMCIsImlkeCI6Mzk3N319LCJfc2RfYWxnIjoic2hhLTI1NiIsImNuZiI6eyJraWQiOiJkaWQ6a2V5Ono2TWtoOXk0TFNGODJvVnJNN0t6cWY2dThVbzFOdVBZclJuZDNvd0JMRUVBRExwZCN6Nk1raDl5NExTRjgyb1ZyTTdLenFmNnU4VW8xTnVQWXJSbmQzb3dCTEVFQURMcGQifX0.-yfZPKWJbeRE45GPqzFIT-wB-f1jXstqR9puEpnobWhY3Ddxf7z1HtZMb4GJcvbOrtcako9ptSxc8keIR-XADw~WyJKbjhUbUh4QmZwLXItd3dCX2h6UEFiS214aEt2R3NMZXJfazBlS21OIiwiZmlyc3RfbmFtZSIsIkZlcnJpcyJd~WyJua0ZZSzV5enZvT0l4c245aF9xcjdHNzJqS2M2ZXo4OVRQZmExb3RYIiwibGFzdF9uYW1lIiwiQ3JhYm1hbiJd~WyJGOUZsRHZ6X0EtbzJuYWw1TzJfaDdoRkQ3MFZTMHlQNFhnczdDQ1U0IiwiZG9iIiwiMTk4Mi0wMS0wMSJd~eyJhbGciOiJSUzI1NiIsInR5cCI6ImtiK2p3dCJ9.eyJpYXQiOjE3NzMyNDc0OTEsImF1ZCI6ImRlY2VudHJhbGl6ZWRfaWRlbnRpZmllcjpkaWQ6a2V5Ono2TWtldXBlUFZLaWtMdjRLWEU5OW9BdlFiZ0FSN3FYcTNBR1V0c1Nlb3FaZ0ZCViIsIm5vbmNlIjoiMWMyYzY4NjRhM2Y0ZTMzNTcxMmJiNzg5MDI0OWQzYzQ2ZTE3N2RkNjJlM2U5M2JjM2E0ZDA4YWNkZTdkNGFiNCIsInNkX2hhc2giOiJidHdZSFU5Rjd5Q2liNDZDN0pWaElwa2pHTUxER2xZeGFvTmZab2NsSzZrIn0.AcganwldnIvrZd_4ube0es_NLo-A8mRo6XL-z0sRkE4Sp9XgeqyLV_0FK6Nx8TWk1zcd3xYZS7eAQWdU3JLcDg";
+    const VALID_VC_SD_JWT_CREDENTIAL: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2g5eTRMU0Y4Mm9Wck03S3pxZjZ1OFVvMU51UFlyUm5kM293QkxFRUFETHBkI3o2TWtoOXk0TFNGODJvVnJNN0t6cWY2dThVbzFOdVBZclJuZDNvd0JMRUVBRExwZCJ9.eyJAY29udGV4dCI6Imh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsInR5cGUiOiJWZXJpZmlhYmxlUHJlc2VudGF0aW9uIiwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjoiaHR0cHM6Ly93d3cudzMub3JnL25zL2NyZWRlbnRpYWxzL3YyIiwiaWQiOiJkYXRhOmFwcGxpY2F0aW9uL3ZjK3NkLWp3dCxleUowZVhBaU9pSjJZeXR6WkMxcWQzUWlMQ0pyYVdRaU9pSmthV1E2YTJWNU9ubzJUV3RsZFhCbFVGWkxhV3RNZGpSTFdFVTVPVzlCZGxGaVowRlNOM0ZZY1ROQlIxVjBjMU5sYjNGYVowWkNWaU42TmsxclpYVndaVkJXUzJsclRIWTBTMWhGT1RsdlFYWlJZbWRCVWpkeFdIRXpRVWRWZEhOVFpXOXhXbWRHUWxZaUxDSmhiR2NpT2lKRlpFUlRRU0o5LmV5SmpjbVZrWlc1MGFXRnNVM1ZpYW1WamRDSTZleUpmYzJRaU9sc2lSa1JaYzNkemFTMTVlREJoUWtOb2VrVmZiVVJxU21GMmJIRnNUVkZMYmtOSk9HWlpabk5JUjFZMVNTSXNJa3RZYURWdWVXWmtNMUJrZEZWSWNXTXRaSFpvTFhSSWQybDNhMUF5Ym1SaFUzUTNla1ZETkVSSFlrMGlMQ0pQVTFWSVlVdzVhMVpLTUZGclVWUkpkRVZ3VG5aTlowRkJXbTB6UWxoR2NqbHJRMmRqTkVKUmVGZE5JaXdpVlZWM2FISTBURVZzYzNkeVh6QktSSEEzYkZCU2NVdHRRWFYzZWpOT1FWZ3phWGxoWWxKeWNqRm9ieUpkZlN3aWRIbHdaU0k2V3lKV1pYSnBabWxoWW14bFEzSmxaR1Z1ZEdsaGJDSmRMQ0p1WVcxbElqb2lWa05FVFNBeUxqQWdVMFF0U2xkVUlFTnlaV1JsYm5ScFlXd2lMQ0pwYzNOMVpYSWlPbnNpYm1GdFpTSTZJbFZ1YVVOdmNtVWlMQ0pwWkNJNkltUnBaRHByWlhrNmVqWk5hMlYxY0dWUVZrdHBhMHgyTkV0WVJUazViMEYyVVdKblFWSTNjVmh4TTBGSFZYUnpVMlZ2Y1ZwblJrSldJbjBzSWtCamIyNTBaWGgwSWpwYkltaDBkSEJ6T2k4dmQzZDNMbmN6TG05eVp5OXVjeTlqY21Wa1pXNTBhV0ZzY3k5Mk1pSmRMQ0pwYzNOMVlXNWpaVVJoZEdVaU9pSXlNREkyTFRBekxURXhWREUyT2pRNU9qVTJXaUlzSW5aaGJHbGtSbkp2YlNJNklqSXdNall0TURNdE1URlVNVFk2TkRrNk5UWmFJaXdpWTNKbFpHVnVkR2xoYkZOMFlYUjFjeUk2ZXlKMGVYQmxJam9pYzNSaGRIVnpiR2x6ZEN0cWQzUWlMQ0pwWkNJNkltaDBkSEE2THk5c2IyTmhiR2h2YzNRNk16QXpNeTlwWlhSbUxXOWhkWFJvTFhSdmEyVnVMWE4wWVhSMWN5MXNhWE4wTHpBaUxDSjFjbWtpT2lKb2RIUndPaTh2Ykc5allXeG9iM04wT2pNd016TXZhV1YwWmkxdllYVjBhQzEwYjJ0bGJpMXpkR0YwZFhNdGJHbHpkQzh3SWl3aWFXUjRJam94T0RaOUxDSnpkR0YwZFhNaU9uc2ljM1JoZEhWelgyeHBjM1FpT25zaWRYSnBJam9pYUhSMGNEb3ZMMnh2WTJGc2FHOXpkRG96TURNekwybGxkR1l0YjJGMWRHZ3RkRzlyWlc0dGMzUmhkSFZ6TFd4cGMzUXZNQ0lzSW1sa2VDSTZNVGcyZlgwc0ltbHpjeUk2SW1ScFpEcHJaWGs2ZWpaTmEyVjFjR1ZRVmt0cGEweDJORXRZUlRrNWIwRjJVV0puUVZJM2NWaHhNMEZIVlhSelUyVnZjVnBuUmtKV0lpd2lYM05rWDJGc1p5STZJbk5vWVMweU5UWWlMQ0pqYm1ZaU9uc2lhMmxrSWpvaVpHbGtPbXRsZVRwNk5rMXJhRGw1TkV4VFJqZ3liMVp5VFRkTGVuRm1OblU0Vlc4eFRuVlFXWEpTYm1RemIzZENURVZGUVVSTWNHUWplalpOYTJnNWVUUk1VMFk0TW05V2NrMDNTM3B4WmpaMU9GVnZNVTUxVUZseVVtNWtNMjkzUWt4RlJVRkVUSEJrSW4xOS5yLVFneXVTNGZlUk5ob3haWHctb2NEQ1NWSzR5S29uZUl1SV9nbks5X3JEVUVlR0lFRnZ3Y0pmQ09FYUtXMVF0OG5FZ0ZzSl80UjVJRFZCRmJKck5EZ35XeUpTU1VoeFJuSm5XR1Z5Y2t0bk4xTmhVMDVXZDNsM2FITmtlVFJrUlZaM1lWVlJTV0pTV1ROTklpd2labWx5YzNSZmJtRnRaU0lzSWtabGNuSnBjeUpkfld5SmhPVGx3VTBoQlIzbE5VbVZOYW5ablRFOUJTVXhXWmw5UFpHbFBUMUZGYldwcFQzcFRhREY0SWl3aWJHRnpkRjl1WVcxbElpd2lRM0poWW0xaGJpSmR-V3lKSFNqZFVabEZxZEdKU1VYSnlPR05WVEdKRlZITlBkMGRqWlhOd2NsRTBkM05xUWxOa01tcFlJaXdpWkc5aUlpd2lNVGs0TWkwd01TMHdNU0pkfld5Sk1kMVZvWDNBMWNqbHZUM2RtVVV4NVZFTm1TbXA0YzJWTU5ERnVORkZUT1VGa1gydGFlVjlWSWl3aWFXUWlMQ0prYVdRNmEyVjVPbm8yVFd0b09YazBURk5HT0RKdlZuSk5OMHQ2Y1dZMmRUaFZiekZPZFZCWmNsSnVaRE52ZDBKTVJVVkJSRXh3WkNKZH4iLCJ0eXBlIjoiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwifV0sImhvbGRlciI6ImRpZDprZXk6ejZNa2g5eTRMU0Y4Mm9Wck03S3pxZjZ1OFVvMU51UFlyUm5kM293QkxFRUFETHBkIiwiYXVkIjoiZGVjZW50cmFsaXplZF9pZGVudGlmaWVyOmRpZDprZXk6ejZNa2V1cGVQVktpa0x2NEtYRTk5b0F2UWJnQVI3cVhxM0FHVXRzU2VvcVpnRkJWIiwiZXhwIjo3ODIxMjQ4MjA2LCJpYXQiOjE3NzMyNDgyMDYsImlzcyI6ImRpZDprZXk6ejZNa2g5eTRMU0Y4Mm9Wck03S3pxZjZ1OFVvMU51UFlyUm5kM293QkxFRUFETHBkIiwibm9uY2UiOiI4ZGY5MWE0YTE5Y2IxYmFiZGE4YmI1OTlhYmU1MmNhZWFlNWFhODgxOWYzOGQ3NjJkMTM0NDZhZGQ3YmQwOWY0In0.t8Q4bmZAD2hFcQxLQfKWM21yOnzr-syra6fGgh9IuDzXEbm_J4ZiJ6YoD8b7eQkB431TDuRGzx57oEAkD8YgCA";
+
+    #[tokio::test]
+    async fn test_validate_vp_token_with_jwt_vc_json() {
+        let dcql_query = DcqlQuery {
+            credentials: vec![CredentialQuery {
+                id: CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                format: Format::JwtVcJson,
+                multiple: None,
+                meta: MetaTypes::W3CFormatMeta {
+                    type_values: vec![vec!["VerifiableCredential".to_string()]],
+                },
+                trusted_authorities: None,
+                require_cryptographic_holder_binding: Some(true),
+                claims: Some(vec![ClaimQuery {
+                    id: None,
+                    path: ClaimPathPointer::try_new(vec![
+                        ClaimPathElement::String("credentialSubject".to_string()),
+                        ClaimPathElement::String("first_name".to_string()),
+                    ])
+                    .unwrap(),
+                    values: None,
+                }]),
+                claim_sets: None,
+            }],
+            credential_sets: None,
+        };
+
+        let vp_token = VpToken::builder()
+            .add_presentations(
+                CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                Presentations::try_new(vec![VALID_JWT_VC_JSON_CREDENTIAL.into()]).unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        assert!(
+            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+                .validate_vp_token(
+                    &dcql_query,
+                    &vp_token,
+                    "decentralized_identifier:did:key:z6MkeupePVKikLv4KXE99oAvQbgAR7qXq3AGUtsSeoqZgFBV",
+                    Some("be1a1b20084f6566033de7bc2f90b837722feab4ab6af71cecb89ff42745abcd"),
+                )
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_vp_token_with_dc_sd_jwt() {
+        let dcql_query = DcqlQuery {
+            credentials: vec![CredentialQuery {
+                id: CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                format: Format::DcSdJwt,
+                multiple: None,
+                meta: MetaTypes::SdJwtMeta {
+                    vct_values: vec!["http://localhost:3033/vct/U0QtSldU/0".to_string()],
+                },
+                trusted_authorities: None,
+                require_cryptographic_holder_binding: Some(true),
+                claims: Some(vec![ClaimQuery {
+                    id: None,
+                    path: ClaimPathPointer::try_new(vec![ClaimPathElement::String("first_name".to_string())]).unwrap(),
+                    values: None,
+                }]),
+                claim_sets: None,
+            }],
+            credential_sets: None,
+        };
+
+        let vp_token = VpToken::builder()
+            .add_presentations(
+                CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                Presentations::try_new(vec![VALID_DC_SD_JWT_CREDENTIAL.into()]).unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        assert!(
+            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+                .validate_vp_token(
+                    &dcql_query,
+                    &vp_token,
+                    "decentralized_identifier:did:key:z6MkeupePVKikLv4KXE99oAvQbgAR7qXq3AGUtsSeoqZgFBV",
+                    Some("1c2c6864a3f4e335712bb7890249d3c46e177dd62e3e93bc3a4d08acde7d4ab4"),
+                )
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_vp_token_with_vc_sd_jwt() {
+        let dcql_query = DcqlQuery {
+            credentials: vec![CredentialQuery {
+                id: CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                format: Format::VcSdJwt,
+                multiple: None,
+                meta: MetaTypes::W3CFormatMeta {
+                    type_values: vec![vec!["VerifiableCredential".to_string()]],
+                },
+                trusted_authorities: None,
+                require_cryptographic_holder_binding: Some(true),
+                claims: Some(vec![ClaimQuery {
+                    id: None,
+                    path: ClaimPathPointer::try_new(vec![
+                        ClaimPathElement::String("credentialSubject".to_string()),
+                        ClaimPathElement::String("first_name".to_string()),
+                    ])
+                    .unwrap(),
+                    values: None,
+                }]),
+                claim_sets: None,
+            }],
+            credential_sets: None,
+        };
+
+        let vp_token = VpToken::builder()
+            .add_presentations(
+                CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                Presentations::try_new(vec![VALID_VC_SD_JWT_CREDENTIAL.into()]).unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        assert!(
+            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+                .validate_vp_token(
+                    &dcql_query,
+                    &vp_token,
+                    "decentralized_identifier:did:key:z6MkeupePVKikLv4KXE99oAvQbgAR7qXq3AGUtsSeoqZgFBV",
+                    Some("8df91a4a19cb1babda8bb599abe52caeae5aa8819f38d762d13446add7bd09f4"),
+                )
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_credential_claim_results_in_dcql_evaluation_fail() {
+        let dcql_query = DcqlQuery {
+            credentials: vec![CredentialQuery {
+                id: CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                format: Format::JwtVcJson,
+                multiple: None,
+                meta: MetaTypes::W3CFormatMeta {
+                    type_values: vec![vec!["VerifiableCredential".to_string()]],
+                },
+                trusted_authorities: None,
+                require_cryptographic_holder_binding: Some(true),
+                claims: Some(vec![ClaimQuery {
+                    id: None,
+                    path: ClaimPathPointer::try_new(vec![
+                        ClaimPathElement::String("credentialSubject".to_string()),
+                        // This claim does not exist in the credential, so the DCQL evaluation should fail
+                        ClaimPathElement::String("different_claim".to_string()),
+                    ])
+                    .unwrap(),
+                    values: None,
+                }]),
+                claim_sets: None,
+            }],
+            credential_sets: None,
+        };
+
+        let vp_token = VpToken::builder()
+            .add_presentations(
+                CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                Presentations::try_new(vec![VALID_JWT_VC_JSON_CREDENTIAL.into()]).unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+                .validate_vp_token(
+                    &dcql_query,
+                    &vp_token,
+                    "decentralized_identifier:did:key:z6MkeupePVKikLv4KXE99oAvQbgAR7qXq3AGUtsSeoqZgFBV",
+                    Some("be1a1b20084f6566033de7bc2f90b837722feab4ab6af71cecb89ff42745abcd"),
+                )
+                .await
+                .unwrap_err(),
+            // The JWT VC JSON credential is valid, but the claim query is looking for a claim that does not exist in the credential, so the DCQL evaluation should fail
+            VpTokenValidationError::DcqlEvaluationFailed
+        ));
+    }
+
+    #[tokio::test]
+    async fn nonce_mismatch_results_in_invalid_nonce_error() {
+        let dcql_query = DcqlQuery {
+            credentials: vec![CredentialQuery {
+                id: CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                format: Format::JwtVcJson,
+                multiple: None,
+                meta: MetaTypes::W3CFormatMeta {
+                    type_values: vec![vec!["VerifiableCredential".to_string()]],
+                },
+                trusted_authorities: None,
+                require_cryptographic_holder_binding: Some(true),
+                claims: Some(vec![ClaimQuery {
+                    id: None,
+                    path: ClaimPathPointer::try_new(vec![
+                        ClaimPathElement::String("credentialSubject".to_string()),
+                        ClaimPathElement::String("first_name".to_string()),
+                    ])
+                    .unwrap(),
+                    values: None,
+                }]),
+                claim_sets: None,
+            }],
+            credential_sets: None,
+        };
+
+        let vp_token = VpToken::builder()
+            .add_presentations(
+                CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                Presentations::try_new(vec![VALID_JWT_VC_JSON_CREDENTIAL.into()]).unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+                .validate_vp_token(
+                    &dcql_query,
+                    &vp_token,
+                    "decentralized_identifier:did:key:z6MkeupePVKikLv4KXE99oAvQbgAR7qXq3AGUtsSeoqZgFBV",
+                    // This nonce does not match the one in the VP token.
+                    Some("different nonce that does not match the one in the VP token"),
+                )
+                .await
+                .unwrap_err(),
+            // The JWT VC JSON credential is valid and the claim query is looking for a claim that exists in the
+            // credential, but the nonce does not match the one in the VP token, so the validation should fail with an
+            // InvalidNonce error.
+            VpTokenValidationError::InvalidNonce { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn wrong_credential_format_results_in_presentation_validation_error() {
+        let dcql_query = DcqlQuery {
+            credentials: vec![CredentialQuery {
+                id: CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                // This DCQL query is looking for a VC SD-JWT credential, but the VP token will contain a JWT VC JSON
+                // credential.
+                format: Format::VcSdJwt,
+                multiple: None,
+                meta: MetaTypes::W3CFormatMeta {
+                    type_values: vec![vec!["VerifiableCredential".to_string()]],
+                },
+                trusted_authorities: None,
+                require_cryptographic_holder_binding: Some(true),
+                claims: Some(vec![ClaimQuery {
+                    id: None,
+                    path: ClaimPathPointer::try_new(vec![
+                        ClaimPathElement::String("credentialSubject".to_string()),
+                        ClaimPathElement::String("first_name".to_string()),
+                    ])
+                    .unwrap(),
+                    values: None,
+                }]),
+                claim_sets: None,
+            }],
+            credential_sets: None,
+        };
+
+        let vp_token = VpToken::builder()
+            .add_presentations(
+                CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                // The VP token contains a JWT VC JSON credential, but the DCQL query is looking for a VC SD-JWT
+                // credential.
+                Presentations::try_new(vec![VALID_JWT_VC_JSON_CREDENTIAL.into()]).unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+                .validate_vp_token(
+                    &dcql_query,
+                    &vp_token,
+                    "decentralized_identifier:did:key:z6MkeupePVKikLv4KXE99oAvQbgAR7qXq3AGUtsSeoqZgFBV",
+                    Some("be1a1b20084f6566033de7bc2f90b837722feab4ab6af71cecb89ff42745abcd"),
+                )
+                .await
+                .unwrap_err(),
+            // The JWT VC JSON credential is valid and the nonce matches, but the DCQL query is looking for a VC SD-JWT
+            // credential, so the validation should fail with a PresentationValidation error indicating that the
+            // credential format does not match the expected format.
+            VpTokenValidationError::PresentationValidation { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn client_id_mismatch_results_in_invalid_audience_error() {
+        let dcql_query = DcqlQuery {
+            credentials: vec![CredentialQuery {
+                id: CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                format: Format::JwtVcJson,
+                multiple: None,
+                meta: MetaTypes::W3CFormatMeta {
+                    type_values: vec![vec!["VerifiableCredential".to_string()]],
+                },
+                trusted_authorities: None,
+                require_cryptographic_holder_binding: Some(true),
+                claims: Some(vec![ClaimQuery {
+                    id: None,
+                    path: ClaimPathPointer::try_new(vec![
+                        ClaimPathElement::String("credentialSubject".to_string()),
+                        ClaimPathElement::String("first_name".to_string()),
+                    ])
+                    .unwrap(),
+                    values: None,
+                }]),
+                claim_sets: None,
+            }],
+            credential_sets: None,
+        };
+
+        let vp_token = VpToken::builder()
+            .add_presentations(
+                CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                Presentations::try_new(vec![VALID_JWT_VC_JSON_CREDENTIAL.into()]).unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+                .validate_vp_token(
+                    &dcql_query,
+                    &vp_token,
+                    // The VP token is valid and the claim query is looking for a claim that exists in the credential,
+                    // but the client ID (audience) does not match the one in the VP token, so the validation should
+                    // fail with an InvalidAudience error.
+                    "decentralized_identifier:did:key:z6MkiTcXZ1JxooACo99YcfkugH6Kifzj7ZupSDCmLEABpjpF",
+                    Some("be1a1b20084f6566033de7bc2f90b837722feab4ab6af71cecb89ff42745abcd"),
+                )
+                .await
+                .unwrap_err(),
+            VpTokenValidationError::InvalidAudience { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn credential_query_id_mismatch_results_in_not_found_error() {
+        let dcql_query = DcqlQuery {
+            credentials: vec![CredentialQuery {
+                id: CredentialQueryId::try_new("CredentialQuery").unwrap(),
+                format: Format::JwtVcJson,
+                multiple: None,
+                meta: MetaTypes::W3CFormatMeta {
+                    type_values: vec![vec!["VerifiableCredential".to_string()]],
+                },
+                trusted_authorities: None,
+                require_cryptographic_holder_binding: Some(true),
+                claims: Some(vec![ClaimQuery {
+                    id: None,
+                    path: ClaimPathPointer::try_new(vec![
+                        ClaimPathElement::String("credentialSubject".to_string()),
+                        ClaimPathElement::String("first_name".to_string()),
+                    ])
+                    .unwrap(),
+                    values: None,
+                }]),
+                claim_sets: None,
+            }],
+            credential_sets: None,
+        };
+
+        let vp_token = VpToken::builder()
+            .add_presentations(
+                // The VP token contains a presentation for a Credential Query with a different ID:
+                // "DifferentCredentialQueryID".
+                CredentialQueryId::try_new("DifferentCredentialQueryID").unwrap(),
+                Presentations::try_new(vec![VALID_JWT_VC_JSON_CREDENTIAL.into()]).unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            VpTokenValidator::new(SignatureVerifier, TestVerificationMaterialResolver)
+                .validate_vp_token(
+                    &dcql_query,
+                    &vp_token,
+                    "decentralized_identifier:did:key:z6MkeupePVKikLv4KXE99oAvQbgAR7qXq3AGUtsSeoqZgFBV",
+                    Some("be1a1b20084f6566033de7bc2f90b837722feab4ab6af71cecb89ff42745abcd"),
+                )
+                .await
+                .unwrap_err(),
+            // The JWT VC JSON credential is valid, the nonce matches, and the client ID matches, but the VP token
+            // contains a presentation for a Credential Query with a different ID than the one in the DCQL query, so
+            // the validation should fail with a CredentialQueryNotFound error indicating that there is no
+            // presentation in the VP token for the Credential Query in the DCQL query.
+            VpTokenValidationError::CredentialQueryNotFound { .. }
+        ));
+    }
+}

--- a/siopv2/src/relying_party.rs
+++ b/siopv2/src/relying_party.rs
@@ -51,6 +51,9 @@ impl RelyingParty {
         .await
     }
 
+    #[deprecated(
+        note = "This function is only used for validating `SIOPv2` Authorization Responses. For validating `OID4VP` Authorization Responses use the `VpTokenValidator` instead."
+    )]
     /// Validates a [`AuthorizationResponse`] by decoding the header of the id_token, fetching the public key corresponding to
     /// the key identifier and finally decoding the id_token using the public key and by validating the signature.
     pub async fn validate_response<E: Extension>(


### PR DESCRIPTION
# Description of change

This PR implementation introduces a comprehensive validation flow for OID4VP Verifiable Presentations using DCQL (Digital Credential Query Language), along with necessary infrastructure updates and dependency improvements.

*   **Implement `VpTokenValidator`**: Ideally suited for OID4VP Authorization Responses, this new validator handles:
    *   Structural validation of the `vp_token` against a `DcqlQuery`.
    *   Cryptographic verification of `jwt_vc_json`, `dc+sd-jwt`, and `vc+sd-jwt` presentation formats.
    *   Resolution of holder binding (key binding) and audience/nonce checks.
    *   Semantic evaluation of claims using the DCQL logic (credential sets, claim selection).
*   **Deprecate Legacy Validation**: Marked `RelyingParty::validate_response` as deprecated for OID4VP flows, steering users towards the new `VpTokenValidator`.
*   **Refactor Error Handling**: The `validator` crate was not functionally used, once it's Error types where utilized so I have replaced it with custom `thiserror` types (`DcqlQueryError`, `MetaError`, `VpTokenBuilderError`, `DcqlClaimsError`) for more granular and idiomatic error reporting across DCQL and token parsing modules.
*   **Infrastructure & Types**:
    *   Added `VerificationMaterialResolver` trait for abstracting DID/Key resolution.
    *   Added `SignatureVerifier` implementation using `identity_verification`.
    *   Introduced `StringOrObject` utility and `Presentations` newtype for flexible JSON handling.
*   **Dependency Updates**: Updated `Cargo.toml` to include necessary `identity-*` crates. (the patch changes can be seen here: https://github.com/iotaledger/identity/compare/v1.9.1-beta.1...impierce:identity.rs:fix/issues?expand=1)

**Breaking change**
- Usage of `RelyingPartyManager::validate_response` for OID4VP Authorization Responses has been deprecated. Use `VpTokenValidator` instead.
- `fn evaluate_dcql_query` and `fn evaluate_credential_query` arguments have been changed to use strong typing.

## Links to any relevant issues
n/a

## How the change has been tested
- added several unit tests for `VpTokenValidator`
- added tests for `StringOrObject`
- The updates in this code are utilized [here](https://github.com/impierce/identity-wallet/pull/710) and [here](https://github.com/impierce/ssi-agent/pull/299)

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes